### PR TITLE
IOS and Android VC transfer stability fixes

### DIFF
--- a/machines/openIdBle/scan.ts
+++ b/machines/openIdBle/scan.ts
@@ -44,7 +44,7 @@ import { isBLEEnabled } from '../../lib/smartshare';
 import { createQrLoginMachine, qrLoginMachine } from '../QrLoginMachine';
 import { StoreEvents } from '../store';
 
-const { GoogleNearbyMessages, IdpassSmartshare } = SmartshareReactNative;
+const { GoogleNearbyMessages } = SmartshareReactNative;
 const { Openid4vpBle } = OpenIdBle;
 
 type SharingProtocol = 'OFFLINE' | 'ONLINE';
@@ -620,14 +620,14 @@ export const scanMachine =
           loggers: (context) => {
             if (context.sharingProtocol === 'OFFLINE' && __DEV__) {
               return [
-                IdpassSmartshare.handleNearbyEvents((event) => {
+                Openid4vpBle.handleNearbyEvents((event) => {
                   console.log(
                     getDeviceNameSync(),
                     '<Sender.Event>',
                     JSON.stringify(event).slice(0, 100)
                   );
                 }),
-                IdpassSmartshare.handleLogEvents((event) => {
+                Openid4vpBle.handleLogEvents((event) => {
                   console.log(
                     getDeviceNameSync(),
                     '<Sender.Log>',
@@ -774,13 +774,14 @@ export const scanMachine =
 
         monitorConnection: (context) => (callback) => {
           if (context.sharingProtocol === 'OFFLINE') {
-            const subscription = IdpassSmartshare.handleNearbyEvents(
-              (event) => {
-                if (event.type === 'onDisconnected') {
-                  callback({ type: 'DISCONNECT' });
-                }
+            const subscription = Openid4vpBle.handleNearbyEvents((event) => {
+              if (event.type === 'onDisconnected') {
+                callback({ type: 'DISCONNECT' });
               }
-            );
+              if (event.type === 'onDisconnected') {
+                callback({ type: 'DISCONNECT' });
+              }
+            });
 
             return () => subscription.remove();
           }

--- a/machines/openIdBle/scan.ts
+++ b/machines/openIdBle/scan.ts
@@ -778,9 +778,6 @@ export const scanMachine =
               if (event.type === 'onDisconnected') {
                 callback({ type: 'DISCONNECT' });
               }
-              if (event.type === 'onDisconnected') {
-                callback({ type: 'DISCONNECT' });
-              }
             });
 
             return () => subscription.remove();

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "react-native-gesture-handler": "~2.1.0",
         "react-native-keychain": "^8.0.0",
         "react-native-location-enabler": "^4.1.0",
-        "react-native-openid4vp-ble": "github:mosip/tuvali#v0.2.4",
+        "react-native-openid4vp-ble": "github:mosip/tuvali#v0.3.1",
         "react-native-permissions": "^3.6.0",
         "react-native-popable": "^0.4.3",
         "react-native-qrcode-svg": "^6.1.1",
@@ -21180,8 +21180,8 @@
       }
     },
     "node_modules/react-native-openid4vp-ble": {
-      "version": "0.2.4",
-      "resolved": "git+ssh://git@github.com/mosip/tuvali.git#f8aa3232a7b7cc4c4f53f38f7771da30aee313a4",
+      "version": "0.3.1",
+      "resolved": "git+ssh://git@github.com/mosip/tuvali.git#84896a9b4826740d9c8a8d3ff63228577261ffe4",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",
@@ -44132,8 +44132,8 @@
       "requires": {}
     },
     "react-native-openid4vp-ble": {
-      "version": "git+ssh://git@github.com/mosip/tuvali.git#f8aa3232a7b7cc4c4f53f38f7771da30aee313a4",
-      "from": "react-native-openid4vp-ble@github:mosip/tuvali#v0.2.4",
+      "version": "git+ssh://git@github.com/mosip/tuvali.git#84896a9b4826740d9c8a8d3ff63228577261ffe4",
+      "from": "react-native-openid4vp-ble@github:mosip/tuvali#v0.3.1",
       "requires": {}
     },
     "react-native-permissions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "react-native-gesture-handler": "~2.1.0",
         "react-native-keychain": "^8.0.0",
         "react-native-location-enabler": "^4.1.0",
-        "react-native-openid4vp-ble": "github:mosip/tuvali#v0.2.2",
+        "react-native-openid4vp-ble": "github:mosip/tuvali#v0.2.4",
         "react-native-permissions": "^3.6.0",
         "react-native-popable": "^0.4.3",
         "react-native-qrcode-svg": "^6.1.1",
@@ -21180,8 +21180,8 @@
       }
     },
     "node_modules/react-native-openid4vp-ble": {
-      "version": "0.2.2",
-      "resolved": "git+ssh://git@github.com/mosip/tuvali.git#5dad650438fd85ba78a1a19b789411bbd7c58681",
+      "version": "0.2.4",
+      "resolved": "git+ssh://git@github.com/mosip/tuvali.git#f8aa3232a7b7cc4c4f53f38f7771da30aee313a4",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",
@@ -44132,8 +44132,8 @@
       "requires": {}
     },
     "react-native-openid4vp-ble": {
-      "version": "git+ssh://git@github.com/mosip/tuvali.git#5dad650438fd85ba78a1a19b789411bbd7c58681",
-      "from": "react-native-openid4vp-ble@github:mosip/tuvali#v0.2.2",
+      "version": "git+ssh://git@github.com/mosip/tuvali.git#f8aa3232a7b7cc4c4f53f38f7771da30aee313a4",
+      "from": "react-native-openid4vp-ble@github:mosip/tuvali#v0.2.4",
       "requires": {}
     },
     "react-native-permissions": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-native-gesture-handler": "~2.1.0",
     "react-native-keychain": "^8.0.0",
     "react-native-location-enabler": "^4.1.0",
-    "react-native-openid4vp-ble": "github:mosip/tuvali#v0.2.4",
+    "react-native-openid4vp-ble": "github:mosip/tuvali#v0.3.1",
     "react-native-permissions": "^3.6.0",
     "react-native-popable": "^0.4.3",
     "react-native-qrcode-svg": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-native-gesture-handler": "~2.1.0",
     "react-native-keychain": "^8.0.0",
     "react-native-location-enabler": "^4.1.0",
-    "react-native-openid4vp-ble": "github:mosip/tuvali#v0.2.2",
+    "react-native-openid4vp-ble": "github:mosip/tuvali#v0.2.4",
     "react-native-permissions": "^3.6.0",
     "react-native-popable": "^0.4.3",
     "react-native-qrcode-svg": "^6.1.1",


### PR DESCRIPTION
Includes the following

1. Implement cancel and disconnect functionality for IOS wallet (#547)
2. Dynamic MTU between IOS to Android and static MTU of 185 between Android to Android (#409)
3. Rename UUID characteristic names to the one used on spec (#444)
4. Remove un necessary bluetooth characteristics permissions and properties (#485)
5. Add logs for investigating Android GCM issue (#525)

Note: This release will be incompatible with earlier app versions. Both Wallet and Verifier should be updated to the current version to have the VC transfer to work.