### PR TITLE
Android & IOS stability Release build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "react-native-gesture-handler": "~2.1.0",
         "react-native-keychain": "^8.0.0",
         "react-native-location-enabler": "^4.1.0",
-        "react-native-openid4vp-ble": "github:mosip/tuvali#v0.3.5",
+        "react-native-openid4vp-ble": "github:mosip/tuvali#v0.3.6",
         "react-native-permissions": "^3.6.0",
         "react-native-popable": "^0.4.3",
         "react-native-qrcode-svg": "^6.1.1",
@@ -21180,8 +21180,8 @@
       }
     },
     "node_modules/react-native-openid4vp-ble": {
-      "version": "0.3.5",
-      "resolved": "git+ssh://git@github.com/mosip/tuvali.git#8eb5bede85b1a08c76870151c45ad0077c6a2eee",
+      "version": "0.3.6",
+      "resolved": "git+ssh://git@github.com/mosip/tuvali.git#c01818c55c26b8589d301d0c66d8c4bc325bbd97",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",
@@ -44132,8 +44132,8 @@
       "requires": {}
     },
     "react-native-openid4vp-ble": {
-      "version": "git+ssh://git@github.com/mosip/tuvali.git#8eb5bede85b1a08c76870151c45ad0077c6a2eee",
-      "from": "react-native-openid4vp-ble@github:mosip/tuvali#v0.3.5",
+      "version": "git+ssh://git@github.com/mosip/tuvali.git#c01818c55c26b8589d301d0c66d8c4bc325bbd97",
+      "from": "react-native-openid4vp-ble@github:mosip/tuvali#v0.3.6",
       "requires": {}
     },
     "react-native-permissions": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-native-gesture-handler": "~2.1.0",
     "react-native-keychain": "^8.0.0",
     "react-native-location-enabler": "^4.1.0",
-    "react-native-openid4vp-ble": "github:mosip/tuvali#v0.3.5",
+    "react-native-openid4vp-ble": "github:mosip/tuvali#v0.3.6",
     "react-native-permissions": "^3.6.0",
     "react-native-popable": "^0.4.3",
     "react-native-qrcode-svg": "^6.1.1",


### PR DESCRIPTION
**Enhancements as part of this release:**
- [iOS ]Disconnect connection when transfer is complete and verifier responds [mosip/inji/issues/593]
- [Android] Increase delay time during mtu exchange to 500ms  [mosip/inji/issues/566]
- [Android] Handle incomplete sequence numbers  [mosip/inji/issues/594]
- Remove all unnecessary logs  from android and change all print statements to OS_logs in iOS  [mosip/inji/issues/568]
- Refactor logTags to display className and versionTag of tuvali  [mosip/inji/issues/576]
- Display the selected VC while transferring the VC [mosip/inji/issues/590]

**Defects:**
- [iOS] Transfer Report writing with response and retry 3 times if it is not able to write  [mosip/inji/issues/567,  mosip/inji/issues/543]