### PR TITLE
chore(#696): Fix compile errors on windows machine due to Tuvali's incorrect build scripts for windows machine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "react-native-gesture-handler": "~2.1.0",
         "react-native-keychain": "^8.0.0",
         "react-native-location-enabler": "^4.1.0",
-        "react-native-openid4vp-ble": "github:mosip/tuvali#v0.3.9",
+        "react-native-openid4vp-ble": "github:mosip/tuvali#v0.3.10",
         "react-native-permissions": "^3.6.0",
         "react-native-popable": "^0.4.3",
         "react-native-qrcode-svg": "^6.1.1",
@@ -21180,8 +21180,8 @@
       }
     },
     "node_modules/react-native-openid4vp-ble": {
-      "version": "0.3.9",
-      "resolved": "git+ssh://git@github.com/mosip/tuvali.git#b16c5eaf0095036d3bcd0ffc2512f5dea5778851",
+      "version": "0.3.10",
+      "resolved": "git+ssh://git@github.com/mosip/tuvali.git#93eb32c3f5a3a844569e60613491a8b81ca8fef8",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",
@@ -44132,8 +44132,8 @@
       "requires": {}
     },
     "react-native-openid4vp-ble": {
-      "version": "git+ssh://git@github.com/mosip/tuvali.git#b16c5eaf0095036d3bcd0ffc2512f5dea5778851",
-      "from": "react-native-openid4vp-ble@github:mosip/tuvali#v0.3.9",
+      "version": "git+ssh://git@github.com/mosip/tuvali.git#93eb32c3f5a3a844569e60613491a8b81ca8fef8",
+      "from": "react-native-openid4vp-ble@github:mosip/tuvali#v0.3.10",
       "requires": {}
     },
     "react-native-permissions": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-native-gesture-handler": "~2.1.0",
     "react-native-keychain": "^8.0.0",
     "react-native-location-enabler": "^4.1.0",
-    "react-native-openid4vp-ble": "github:mosip/tuvali#v0.3.9",
+    "react-native-openid4vp-ble": "github:mosip/tuvali#v0.3.10",
     "react-native-permissions": "^3.6.0",
     "react-native-popable": "^0.4.3",
     "react-native-qrcode-svg": "^6.1.1",


### PR DESCRIPTION
This fixes the compile time errors occurring in Inji due to Tuvali's npm executable scripts. These scripts were originally build for mac machine in the initial days when Inji app was not there. Now these Tuvali executable scripts aren't used.