### PR TITLE
Update android target and compile sdk to API level 33

### DIFF
--- a/android/app/src/main/java/io/mosip/residentapp/MainActivity.java
+++ b/android/app/src/main/java/io/mosip/residentapp/MainActivity.java
@@ -13,7 +13,6 @@ import androidx.core.content.ContextCompat;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
-import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
 import expo.modules.ReactActivityDelegateWrapper;
 
 /**
@@ -108,18 +107,5 @@ public class MainActivity extends ReactActivity {
       }
     }
     recreate();
-  }
-
-  @Override
-  protected ReactActivityDelegate createReactActivityDelegate() {
-    return new ReactActivityDelegateWrapper(
-      this,
-      new ReactActivityDelegate(this, getMainComponentName()) {
-        @Override
-        protected ReactRootView createRootView() {
-          return new RNGestureHandlerEnabledRootView(MainActivity.this);
-        }
-      }
-    );
   }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         buildToolsVersion = "29.0.3"
         minSdkVersion = 23
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 33
+        targetSdkVersion = 33
     }
     repositories {
         google()

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react-native-dotenv": "^3.3.1",
     "react-native-elements": "3.4.2",
     "react-native-fs": "^2.20.0",
-    "react-native-gesture-handler": "~2.1.0",
+    "react-native-gesture-handler": "2.5.0",
     "react-native-keychain": "^8.0.0",
     "react-native-linear-gradient": "^2.6.2",
     "react-native-location": "^2.5.0",


### PR DESCRIPTION
   * bump up react-native-gesture-handler version to 2.5.0
   * remove RNGestureHandlerEnabledRootView as it is not needed in new version of react-native-gesture-handler