### PR TITLE
fix(INJI-371): View-activity-log-screen-header-resolved

### DIFF
--- a/screens/Home/MyVcs/HistoryTab.tsx
+++ b/screens/Home/MyVcs/HistoryTab.tsx
@@ -14,6 +14,7 @@ import testIDProps from '../../../shared/commonUtil';
 export const HistoryTab: React.FC<HistoryTabProps> = (props) => {
   const { t } = useTranslation('HistoryTab');
   const controller = useKebabPopUp(props);
+
   return (
     <ListItem bottomDivider onPress={controller.SHOW_ACTIVITY}>
       <ListItem.Content>
@@ -27,7 +28,7 @@ export const HistoryTab: React.FC<HistoryTabProps> = (props) => {
         </ListItem.Title>
       </ListItem.Content>
       <Modal
-        headerLabel={props.vcKey.split(':')[2]}
+        headerLabel={props.vcKey.split(':')[5]}
         isVisible={controller.isShowActivities}
         onDismiss={controller.DISMISS}>
         <Column fill>


### PR DESCRIPTION
**[INJI-371](https://mosip.atlassian.net/browse/INJI-371)**  ->  The hash value of downloaded UIN/VID (downloaded vc) is shown on top of the "view activity log" screen in inji UI

[INJI-371]: https://mosip.atlassian.net/browse/INJI-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ