### PR TITLE
fix(INJI-268)- Adjusted headers of pages to align center

### DIFF
--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -42,7 +42,7 @@ export const Modal: React.FC<ModalProps> = props => {
             <Row
               fill
               align={props.headerLeft ? 'flex-start' : 'center'}
-              margin={'16 0 0 -21'}>
+              margin={'16 0 0 -20'}>
               <Column>
                 <Text testID={props.testID} style={Theme.TextStyles.header}>
                   {props.headerTitle || props.headerLeft}


### PR DESCRIPTION
**[INJI-268](https://mosip.atlassian.net/browse/INJI-268)** - Page headers are not aligned properly

[INJI-268]: https://mosip.atlassian.net/browse/INJI-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ