### PR TITLE
feat(INJI-419): notify user on minStorageLimitReached while vc download

### DIFF
--- a/screens/Home/HomeScreen.tsx
+++ b/screens/Home/HomeScreen.tsx
@@ -14,6 +14,7 @@ import {ExistingMosipVCItemMachine} from '../../machines/VCItemMachine/ExistingM
 import {isOpenId4VCIEnabled} from '../../shared/openId4VCI/Utils';
 import LinearGradient from 'react-native-linear-gradient';
 import {EsignetMosipVCItemMachine} from '../../machines/VCItemMachine/EsignetMosipVCItem/EsignetMosipVCItemMachine';
+import {ErrorMessageOverlay} from '../../components/MessageOverlay';
 
 export const HomeScreen: React.FC<HomeRouteProps> = props => {
   const {t} = useTranslation('HomeScreen');
@@ -76,6 +77,12 @@ export const HomeScreen: React.FC<HomeRouteProps> = props => {
         )}
       </Column>
       {isOpenId4VCIEnabled() && <DownloadFABIcon />}
+      <ErrorMessageOverlay
+        translationPath={'MyVcsTab'}
+        isVisible={controller.isMinimumStorageLimitReached}
+        error={'errors.storageLimitReached'}
+        onDismiss={controller.DISMISS}
+      />
       {controller.selectedVc && (
         <ViewVcModal
           isVisible={controller.isViewingVc}

--- a/screens/Home/HomeScreenController.ts
+++ b/screens/Home/HomeScreenController.ts
@@ -11,6 +11,7 @@ import {
   selectTabsLoaded,
   selectViewingVc,
   selectIssuersMachine,
+  selectIsMinimumStorageLimitReached,
 } from './HomeScreenMachine';
 import {VcEvents} from '../../machines/vc';
 
@@ -42,8 +43,13 @@ export function useHomeScreen(props: HomeRouteProps) {
     haveTabsLoaded: useSelector(service, selectTabsLoaded),
 
     IssuersService: useSelector(service, selectIssuersMachine),
-    GOTO_ISSUERS: () => service.send(HomeScreenEvents.GOTO_ISSUERS()),
+    isMinimumStorageLimitReached: useSelector(
+      service,
+      selectIsMinimumStorageLimitReached,
+    ),
 
+    DISMISS: () => service.send(HomeScreenEvents.DISMISS()),
+    GOTO_ISSUERS: () => service.send(HomeScreenEvents.GOTO_ISSUERS()),
     SELECT_TAB,
     DISMISS_MODAL: () => service.send(HomeScreenEvents.DISMISS_MODAL()),
     REVOKE: () => {

--- a/screens/Home/HomeScreenMachine.ts
+++ b/screens/Home/HomeScreenMachine.ts
@@ -9,6 +9,7 @@ import {
 } from './ReceivedVcsTabMachine';
 import {EsignetMosipVCItemMachine} from '../../machines/VCItemMachine/EsignetMosipVCItem/EsignetMosipVCItemMachine';
 import {IssuersMachine} from '../../machines/issuersMachine';
+import Storage from '../../shared/storage';
 
 const model = createModel(
   {
@@ -37,6 +38,7 @@ const model = createModel(
       DISMISS_MODAL: () => ({}),
       GOTO_ISSUERS: () => ({}),
       DOWNLOAD_ID: () => ({}),
+      DISMISS: () => ({}),
     },
   },
 );
@@ -69,7 +71,7 @@ export const HomeScreenMachine = model.createMachine(
           SELECT_MY_VCS: '.myVcs',
           SELECT_RECEIVED_VCS: '.receivedVcs',
           SELECT_HISTORY: '.history',
-          GOTO_ISSUERS: '.gotoIssuers',
+          GOTO_ISSUERS: '.checkStorage',
         },
         states: {
           init: {
@@ -105,6 +107,25 @@ export const HomeScreenMachine = model.createMachine(
           history: {
             entry: [setActiveTab(2)],
           },
+          checkStorage: {
+            invoke: {
+              src: 'checkStorageAvailability',
+              onDone: [
+                {
+                  cond: 'isMinimumStorageLimitReached',
+                  target: 'storageLimitReached',
+                },
+                {
+                  target: 'gotoIssuers',
+                },
+              ],
+            },
+          },
+          storageLimitReached: {
+            on: {
+              DISMISS: 'idle',
+            },
+          },
           gotoIssuers: {
             invoke: {
               id: 'issuersMachine',
@@ -120,7 +141,7 @@ export const HomeScreenMachine = model.createMachine(
                 actions: 'sendAddEvent',
                 target: 'idle',
               },
-              GOTO_ISSUERS: 'gotoIssuers',
+              GOTO_ISSUERS: 'checkStorage',
             },
           },
           idle: {
@@ -129,7 +150,7 @@ export const HomeScreenMachine = model.createMachine(
                 actions: 'sendAddEvent',
                 target: 'idle',
               },
-              GOTO_ISSUERS: 'gotoIssuers',
+              GOTO_ISSUERS: 'checkStorage',
             },
           },
         },
@@ -156,6 +177,13 @@ export const HomeScreenMachine = model.createMachine(
     },
   },
   {
+    services: {
+      checkStorageAvailability: () => async () => {
+        return Promise.resolve(
+          Storage.isMinimumLimitReached('minStorageRequired'),
+        );
+      },
+    },
     actions: {
       spawnTabActors: assign({
         tabRefs: context => ({
@@ -181,6 +209,9 @@ export const HomeScreenMachine = model.createMachine(
       resetSelectedVc: model.assign({
         selectedVc: null,
       }),
+    },
+    guards: {
+      isMinimumStorageLimitReached: (_context, event) => Boolean(event.data),
     },
   },
 );
@@ -213,4 +244,8 @@ export function selectViewingVc(state: State) {
 
 export function selectTabsLoaded(state: State) {
   return !state.matches('tabs.init');
+}
+
+export function selectIsMinimumStorageLimitReached(state: State) {
+  return state.matches('tabs.storageLimitReached');
 }

--- a/screens/Home/HomeScreenMachine.typegen.ts
+++ b/screens/Home/HomeScreenMachine.typegen.ts
@@ -3,12 +3,19 @@
 export interface Typegen0 {
   '@@xstate/typegen': true;
   internalEvents: {
+    'done.invoke.HomeScreen.tabs.checkStorage:invocation[0]': {
+      type: 'done.invoke.HomeScreen.tabs.checkStorage:invocation[0]';
+      data: unknown;
+      __tip: 'See the XState TS docs to learn how to strongly type this.';
+    };
     'xstate.after(100)#HomeScreen.tabs.init': {
       type: 'xstate.after(100)#HomeScreen.tabs.init';
     };
     'xstate.init': {type: 'xstate.init'};
   };
-  invokeSrcNameMap: {};
+  invokeSrcNameMap: {
+    checkStorageAvailability: 'done.invoke.HomeScreen.tabs.checkStorage:invocation[0]';
+  };
   missingImplementations: {
     actions: never;
     delays: never;
@@ -22,30 +29,37 @@ export interface Typegen0 {
     spawnTabActors: 'xstate.init';
   };
   eventsCausingDelays: {};
-  eventsCausingGuards: {};
+  eventsCausingGuards: {
+    isMinimumStorageLimitReached: 'done.invoke.HomeScreen.tabs.checkStorage:invocation[0]';
+  };
   eventsCausingServices: {
-    issuersMachine: 'GOTO_ISSUERS';
+    checkStorageAvailability: 'GOTO_ISSUERS';
+    issuersMachine: 'done.invoke.HomeScreen.tabs.checkStorage:invocation[0]';
   };
   matchesStates:
     | 'modals'
     | 'modals.none'
     | 'modals.viewingVc'
     | 'tabs'
+    | 'tabs.checkStorage'
     | 'tabs.gotoIssuers'
     | 'tabs.history'
     | 'tabs.idle'
     | 'tabs.init'
     | 'tabs.myVcs'
     | 'tabs.receivedVcs'
+    | 'tabs.storageLimitReached'
     | {
         modals?: 'none' | 'viewingVc';
         tabs?:
+          | 'checkStorage'
           | 'gotoIssuers'
           | 'history'
           | 'idle'
           | 'init'
           | 'myVcs'
-          | 'receivedVcs';
+          | 'receivedVcs'
+          | 'storageLimitReached';
       };
   tags: never;
 }


### PR DESCRIPTION
When user clicks on plus icon in home page for downloading VC, if the device storage is less than the min threshold defined in our inji-default.properties file, error message overlay is shown (attached screenshot)

mosip.inji.minStorageRequired=5

![image](https://github.com/mosip/inji/assets/81218987/713d617e-4635-48d8-90db-cfda37b9fd2a)
