### PR TITLE
fix(INJI-205): vc download via esignet

### DIFF
--- a/machines/issuersMachine.ts
+++ b/machines/issuersMachine.ts
@@ -472,7 +472,7 @@ export const IssuersMachine = model.createMachine(
       downloadCredential: async context => {
         const body = await getBody(context);
         const downloadTimeout = await vcDownloadTimeout();
-        const response = await request(
+        let credential = await request(
           'POST',
           context.selectedIssuer.serviceConfiguration.credentialEndpoint,
           body,
@@ -483,7 +483,6 @@ export const IssuersMachine = model.createMachine(
           },
           downloadTimeout,
         );
-        let credential = await response.json();
         credential = updateCredentialInformation(context, credential);
         return credential;
       },

--- a/machines/issuersMachine.ts
+++ b/machines/issuersMachine.ts
@@ -483,6 +483,9 @@ export const IssuersMachine = model.createMachine(
           },
           downloadTimeout,
         );
+        console.info(
+          `VC download via ${context.selectedIssuerId} is succesfull`,
+        );
         credential = updateCredentialInformation(context, credential);
         return credential;
       },


### PR DESCRIPTION
remove conversion of json in downloaded credential response as request method called is already returning json type response. This eliminates error while vc download via eSignet