### PR TITLE
fix(INJI-260):refactor language setup and intro slider alignment in smaller display

### DIFF
--- a/components/ui/themes/DefaultTheme.ts
+++ b/components/ui/themes/DefaultTheme.ts
@@ -1219,6 +1219,15 @@ export const DefaultTheme = {
       color: Colors.mediumDarkGrey,
     },
   }),
+  SetupLanguageScreenStyle: StyleSheet.create({
+    columnStyle: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'space-around',
+      backgroundColor: Colors.White,
+      maxHeight: Dimensions.get('window').height,
+    },
+  }),
 
   ICON_SMALL_SIZE: 16,
   ICON_MID_SIZE: 22,

--- a/components/ui/themes/PurpleTheme.ts
+++ b/components/ui/themes/PurpleTheme.ts
@@ -1217,6 +1217,16 @@ export const PurpleTheme = {
       color: Colors.mediumDarkGrey,
     },
   }),
+  SetupLanguageScreenStyle: StyleSheet.create({
+    columnStyle: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'space-around',
+      backgroundColor: Colors.White,
+      maxHeight: Dimensions.get('window').height,
+    },
+  }),
+
   ICON_SMALL_SIZE: 16,
   ICON_MID_SIZE: 22,
   PinIcon: require('../../../assets/pin_icon.png'),

--- a/screens/Home/IntroSlidersScreen.tsx
+++ b/screens/Home/IntroSlidersScreen.tsx
@@ -80,7 +80,11 @@ export const IntroSlidersScreen: React.FC<RootRouteProps> = props => {
               )}
             </Column>
           </Row>
-          <Image source={item.image} />
+          <Image
+            source={item.image}
+            resizeMode="contain"
+            style={{height: Dimensions.get('screen').height * 0.6}}
+          />
           <Column
             testID="introSlide"
             style={Theme.OnboardingOverlayStyles.bottomContainer}

--- a/screens/SetupLanguageScreen.tsx
+++ b/screens/SetupLanguageScreen.tsx
@@ -39,11 +39,7 @@ export const SetupLanguageScreen: React.FC<RootRouteProps> = props => {
   };
 
   return (
-    <Column
-      align="space-around"
-      crossAlign="center"
-      backgroundColor={Theme.Colors.whiteBackgroundColor}
-      height={Dimensions.get('window').height * 0.9}>
+    <Column style={Theme.SetupLanguageScreenStyle.columnStyle}>
       <Icon
         name="globe"
         type="simple-line-icon"
@@ -51,14 +47,10 @@ export const SetupLanguageScreen: React.FC<RootRouteProps> = props => {
         size={58}
       />
       <Column crossAlign="center">
-        <Text testID="chooseLanguage" margin="0 0 10 0" weight="semibold">
+        <Text testID="chooseLanguage" margin="10 0 10 0" weight="semibold">
           {t('header')}
         </Text>
-        <Text
-          style={{paddingVertical: 18}}
-          weight="semibold"
-          align="center"
-          color={Theme.Colors.GrayText}>
+        <Text weight="semibold" align="center" color={Theme.Colors.GrayText}>
           {t('description')}
         </Text>
       </Column>


### PR DESCRIPTION
Android:
![Screenshot_1697456660](https://github.com/mosip/inji/assets/97477121/d8042b44-5be0-4d95-a76e-bd05edcd5447)
![Screenshot_1697456654](https://github.com/mosip/inji/assets/97477121/6f86c528-5f08-4c8a-999a-82f637727990)


IOS:
![Screenshot 2023-10-16 at 5 12 01 PM](https://github.com/mosip/inji/assets/97477121/fe81b6ce-fdc1-4845-b554-a13daeeed7ce)
![Screenshot 2023-10-16 at 5 12 15 PM](https://github.com/mosip/inji/assets/97477121/5deab98d-3acc-465c-a8d3-056abc84744a)
