### PR TITLE
chore(INJI-149)!: temporarily disable encryption for iOS

### DIFF
--- a/shared/cryptoutil/cryptoUtil.ts
+++ b/shared/cryptoutil/cryptoUtil.ts
@@ -1,3 +1,10 @@
+/**
+ * NOTE: Encryption for MMKV datastore has been disabled temporarily for
+ *  **iOS devices ONLY** to evaluate the cause of an infrequent data loss
+ *  issue. For more information see
+ * https://github.com/mosip/inji/pull/1006/files &
+ * https://mosip.atlassian.net/browse/INJI-149
+ */
 import {KeyPair, RSA} from 'react-native-rsa-native';
 import forge from 'node-forge';
 import {BIOMETRIC_CANCELLED, DEBUG_MODE_ENABLED, isIOS} from '../constants';
@@ -104,11 +111,10 @@ export async function encryptJson(
   data: string,
 ): Promise<string> {
   try {
-    // Disable Encryption in debug mode
-    if (DEBUG_MODE_ENABLED && __DEV__) {
+    // Disable Encryption in debug mode & for iPhones
+    if ((DEBUG_MODE_ENABLED && __DEV__) || isIOS()) {
       return JSON.stringify(data);
     }
-
     if (!isHardwareKeystoreExists) {
       return CryptoJS.AES.encrypt(data, encryptionKey).toString();
     }
@@ -132,7 +138,7 @@ export async function decryptJson(
       return '';
     }
     // Disable Encryption in debug mode
-    if (DEBUG_MODE_ENABLED && __DEV__) {
+    if ((DEBUG_MODE_ENABLED && __DEV__) || isIOS()) {
       return JSON.parse(encryptedData);
     }
 


### PR DESCRIPTION
# NOTE

This changeset shouldn't be sent to develop and the target merge branch of this PR should be changed or this change must be sent in next release for extensive bug scenario reproduction. cc @swatigoel @vijay151096 

# Background


Inji application on the iOS platform is known to lose data often, basis of INJI-149, we've had different suspicions previously on areas such as

- keystore returning `undefined` due to iPhone in locked state or recently unlocked state(as the keystore might not unlock as soon as the phone is unlocked)
- decryption error due to encryption key change due to former

now we have the encryption library as a suspect because of the following logs, it seems that the data is somehow getting truncated(something not expected if data is encrypted, i.e. when it's tampered, it's lost in whole) as a parallel effort, the alternatives such as `node:crypto`, `CryptoJS` & `node-forge`. It has been observed that data has been lost even when `node-forge` was used instead of `CryptoJS`. To confirm if encryption is not the culprit, we are disabling it and checking if the data is still lost which would confirm that MMKV database is causing the issue.

```log
2023-11-08 11:11:21.557638+0530 Inji[6802:411596] [javascript] Exception in getting item for settings: SyntaxError: JSON Parse error: Unexpected token: q
2023-11-08 11:11:21.560874+0530 Inji[6802:411596] [javascript] Exception in getting item for myVCs: SyntaxError: JSON Parse error: Unexpected end of input
2023-11-08 11:11:21.561630+0530 Inji[6802:411596] [javascript] Exception in getting item for auth: SyntaxError: JSON Parse error: Unexpected end of input
2023-11-08 11:11:21.562474+0530 Inji[6802:411596] [javascript] Exception in getting item for myVCs: SyntaxError: JSON Parse error: Unexpected end of input
2023-11-08 11:11:21.569757+0530 Inji[6802:411596] [javascript] [Harsh Vardhan’s iPhone] settings: STORE_RESPONSE -> storingDefaults
```
