### PR TITLE
feat(INJI-622): add telemetry event to track face model init fail/sucess

### DIFF
--- a/machines/bleShare/scan/scanMachine.typegen.ts
+++ b/machines/bleShare/scan/scanMachine.typegen.ts
@@ -1,236 +1,109 @@
-// This file was automatically generated. Edits will be overwritten
 
-export interface Typegen0 {
-  '@@xstate/typegen': true;
-  internalEvents: {
-    '': {type: ''};
-    'done.invoke.QrLogin': {
-      type: 'done.invoke.QrLogin';
-      data: unknown;
-      __tip: 'See the XState TS docs to learn how to strongly type this.';
-    };
-    'done.invoke.scan.checkStorage:invocation[0]': {
-      type: 'done.invoke.scan.checkStorage:invocation[0]';
-      data: unknown;
-      __tip: 'See the XState TS docs to learn how to strongly type this.';
-    };
-    'done.invoke.scan.reviewing.creatingVp:invocation[0]': {
-      type: 'done.invoke.scan.reviewing.creatingVp:invocation[0]';
-      data: unknown;
-      __tip: 'See the XState TS docs to learn how to strongly type this.';
-    };
-    'xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection': {
-      type: 'xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection';
-    };
-    'xstate.init': {type: 'xstate.init'};
-    'xstate.stop': {type: 'xstate.stop'};
-  };
-  invokeSrcNameMap: {
-    checkBluetoothPermission: 'done.invoke.scan.checkBluetoothPermission.checking:invocation[0]';
-    checkBluetoothState:
-      | 'done.invoke.scan.checkBluetoothState.checking:invocation[0]'
-      | 'done.invoke.scan.recheckBluetoothState.checking:invocation[0]';
-    checkLocationPermission: 'done.invoke.scan.checkingLocationState.checkingPermissionStatus:invocation[0]';
-    checkLocationStatus: 'done.invoke.scan.checkingLocationState.checkLocationService:invocation[0]';
-    checkNearByDevicesPermission: 'done.invoke.scan.checkNearbyDevicesPermission.checking:invocation[0]';
-    checkStorageAvailability: 'done.invoke.scan.checkStorage:invocation[0]';
-    createVp: 'done.invoke.scan.reviewing.creatingVp:invocation[0]';
-    disconnect:
-      | 'done.invoke.scan.clearingConnection:invocation[0]'
-      | 'done.invoke.scan.disconnectDevice:invocation[0]';
-    monitorConnection: 'done.invoke.scan:invocation[0]';
-    requestBluetooth: 'done.invoke.scan.checkBluetoothState.requesting:invocation[0]';
-    requestNearByDevicesPermission: 'done.invoke.scan.checkNearbyDevicesPermission.requesting:invocation[0]';
-    requestToEnableLocationPermission: 'done.invoke.scan.checkingLocationState.requestToEnableLocation:invocation[0]';
-    sendVc: 'done.invoke.scan.reviewing.sendingVc:invocation[0]';
-    startConnection: 'done.invoke.scan.connecting:invocation[0]';
-  };
-  missingImplementations: {
-    actions: never;
-    delays: never;
-    guards: never;
-    services: never;
-  };
-  eventsCausingActions: {
-    clearCreatedVp:
-      | ''
-      | 'BLE_ERROR'
-      | 'DISCONNECT'
-      | 'DISMISS'
-      | 'RESET'
-      | 'SCREEN_BLUR'
-      | 'SCREEN_FOCUS'
-      | 'xstate.stop';
-    clearReason:
-      | ''
-      | 'BLE_ERROR'
-      | 'DISCONNECT'
-      | 'DISMISS'
-      | 'RESET'
-      | 'SCREEN_BLUR'
-      | 'SCREEN_FOCUS'
-      | 'xstate.stop';
-    clearUri:
-      | 'DISCONNECT'
-      | 'DISMISS'
-      | 'xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection';
-    logFailedVerification: 'FACE_INVALID';
-    logShared: 'VC_ACCEPTED';
-    openAppPermission: 'GOTO_SETTINGS' | 'LOCATION_REQUEST';
-    openBluetoothSettings: 'GOTO_SETTINGS';
-    registerLoggers:
-      | 'DISCONNECT'
-      | 'DISMISS'
-      | 'xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection';
-    removeLoggers:
-      | 'DISCONNECT'
-      | 'DISMISS'
-      | 'SCREEN_BLUR'
-      | 'xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection'
-      | 'xstate.init';
-    resetShouldVerifyPresence: 'CANCEL' | 'CONNECTED' | 'DISMISS' | 'RETRY';
-    sendBLEConnectionErrorEvent: 'BLE_ERROR';
-    sendScanData: 'SCAN';
-    sendVCShareFlowCancelEndEvent: 'CANCEL';
-    sendVCShareFlowTimeoutEndEvent: 'CANCEL' | 'RETRY';
-    sendVcShareSuccessEvent: 'VC_ACCEPTED';
-    sendVcSharingStartEvent: 'SCAN';
-    setBleError: 'BLE_ERROR';
-    setChildRef:
-      | 'DISCONNECT'
-      | 'DISMISS'
-      | 'xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection';
-    setCreatedVp: 'done.invoke.scan.reviewing.creatingVp:invocation[0]';
-    setLinkCode: 'SCAN';
-    setReadyForBluetoothStateCheck: 'BLUETOOTH_PERMISSION_ENABLED';
-    setReason: 'UPDATE_REASON';
-    setReceiverInfo: 'CONNECTED';
-    setSelectedVc: 'SELECT_VC';
-    setSenderInfo: 'CONNECTED';
-    setShareLogTypeUnverified: 'ACCEPT_REQUEST';
-    setShareLogTypeVerified: 'FACE_VALID';
-    setUri: 'SCAN';
-    storeLoginItem: 'done.invoke.QrLogin';
-    storingActivityLog: 'STORE_RESPONSE';
-    toggleShouldVerifyPresence: 'TOGGLE_USER_CONSENT';
-  };
-  eventsCausingDelays: {
-    CONNECTION_TIMEOUT: 'SCAN';
-    DESTROY_TIMEOUT: '' | 'DISMISS' | 'LOCATION_ENABLED';
-    SHARING_TIMEOUT:
-      | 'ACCEPT_REQUEST'
-      | 'FACE_VALID'
-      | 'done.invoke.scan.reviewing.creatingVp:invocation[0]';
-  };
-  eventsCausingGuards: {
-    isIOS: 'BLUETOOTH_STATE_DISABLED' | 'START_PERMISSION_CHECK';
-    isMinimumStorageRequiredForAuditEntryReached: 'done.invoke.scan.checkStorage:invocation[0]';
-    isOpenIdQr: 'SCAN';
-    isQrLogin: 'SCAN';
-    uptoAndroid11: '' | 'START_PERMISSION_CHECK';
-  };
-  eventsCausingServices: {
-    QrLogin: 'SCAN';
-    checkBluetoothPermission:
-      | ''
-      | 'BLUETOOTH_STATE_DISABLED'
-      | 'NEARBY_ENABLED'
-      | 'START_PERMISSION_CHECK';
-    checkBluetoothState: '' | 'APP_ACTIVE';
-    checkLocationPermission: 'APP_ACTIVE' | 'LOCATION_ENABLED';
-    checkLocationStatus: '' | 'LOCATION_REQUEST';
-    checkNearByDevicesPermission: 'APP_ACTIVE' | 'START_PERMISSION_CHECK';
-    checkStorageAvailability: 'RESET' | 'SCREEN_FOCUS';
-    createVp: never;
-    disconnect: '' | 'DISMISS' | 'LOCATION_ENABLED' | 'SCREEN_BLUR';
-    monitorConnection: 'DISMISS' | 'SCREEN_BLUR' | 'xstate.init';
-    requestBluetooth: 'BLUETOOTH_STATE_DISABLED';
-    requestNearByDevicesPermission: 'NEARBY_DISABLED';
-    requestToEnableLocationPermission: 'LOCATION_DISABLED';
-    sendVc:
-      | 'ACCEPT_REQUEST'
-      | 'FACE_VALID'
-      | 'done.invoke.scan.reviewing.creatingVp:invocation[0]';
-    startConnection: 'SCAN';
-  };
-  matchesStates:
-    | 'bluetoothDenied'
-    | 'bluetoothPermissionDenied'
-    | 'checkBluetoothPermission'
-    | 'checkBluetoothPermission.checking'
-    | 'checkBluetoothPermission.enabled'
-    | 'checkBluetoothState'
-    | 'checkBluetoothState.checking'
-    | 'checkBluetoothState.enabled'
-    | 'checkBluetoothState.requesting'
-    | 'checkNearbyDevicesPermission'
-    | 'checkNearbyDevicesPermission.checking'
-    | 'checkNearbyDevicesPermission.enabled'
-    | 'checkNearbyDevicesPermission.requesting'
-    | 'checkStorage'
-    | 'checkingLocationState'
-    | 'checkingLocationState.checkLocationService'
-    | 'checkingLocationState.checkingPermissionStatus'
-    | 'checkingLocationState.denied'
-    | 'checkingLocationState.disabled'
-    | 'checkingLocationState.requestToEnableLocation'
-    | 'clearingConnection'
-    | 'connecting'
-    | 'connecting.inProgress'
-    | 'connecting.timeout'
-    | 'disconnectDevice'
-    | 'disconnected'
-    | 'findingConnection'
-    | 'handlingBleError'
-    | 'inactive'
-    | 'invalid'
-    | 'nearByDevicesPermissionDenied'
-    | 'recheckBluetoothState'
-    | 'recheckBluetoothState.checking'
-    | 'recheckBluetoothState.enabled'
-    | 'restrictSharingVc'
-    | 'reviewing'
-    | 'reviewing.accepted'
-    | 'reviewing.cancelling'
-    | 'reviewing.creatingVp'
-    | 'reviewing.invalidIdentity'
-    | 'reviewing.navigatingToHome'
-    | 'reviewing.rejected'
-    | 'reviewing.selectingVc'
-    | 'reviewing.sendingVc'
-    | 'reviewing.sendingVc.inProgress'
-    | 'reviewing.sendingVc.sent'
-    | 'reviewing.sendingVc.timeout'
-    | 'reviewing.verifyingIdentity'
-    | 'showQrLogin'
-    | 'showQrLogin.idle'
-    | 'showQrLogin.navigatingToHistory'
-    | 'showQrLogin.storing'
-    | 'startPermissionCheck'
-    | {
-        checkBluetoothPermission?: 'checking' | 'enabled';
-        checkBluetoothState?: 'checking' | 'enabled' | 'requesting';
-        checkNearbyDevicesPermission?: 'checking' | 'enabled' | 'requesting';
-        checkingLocationState?:
-          | 'checkLocationService'
-          | 'checkingPermissionStatus'
-          | 'denied'
-          | 'disabled'
-          | 'requestToEnableLocation';
-        connecting?: 'inProgress' | 'timeout';
-        recheckBluetoothState?: 'checking' | 'enabled';
-        reviewing?:
-          | 'accepted'
-          | 'cancelling'
-          | 'creatingVp'
-          | 'invalidIdentity'
-          | 'navigatingToHome'
-          | 'rejected'
-          | 'selectingVc'
-          | 'sendingVc'
-          | 'verifyingIdentity'
-          | {sendingVc?: 'inProgress' | 'sent' | 'timeout'};
-        showQrLogin?: 'idle' | 'navigatingToHistory' | 'storing';
-      };
-  tags: never;
-}
+  // This file was automatically generated. Edits will be overwritten
+
+  export interface Typegen0 {
+        '@@xstate/typegen': true;
+        internalEvents: {
+          "": { type: "" };
+"done.invoke.QrLogin": { type: "done.invoke.QrLogin"; data: unknown; __tip: "See the XState TS docs to learn how to strongly type this." };
+"done.invoke.scan.checkStorage:invocation[0]": { type: "done.invoke.scan.checkStorage:invocation[0]"; data: unknown; __tip: "See the XState TS docs to learn how to strongly type this." };
+"done.invoke.scan.reviewing.creatingVp:invocation[0]": { type: "done.invoke.scan.reviewing.creatingVp:invocation[0]"; data: unknown; __tip: "See the XState TS docs to learn how to strongly type this." };
+"xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection": { type: "xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection" };
+"xstate.init": { type: "xstate.init" };
+"xstate.stop": { type: "xstate.stop" };
+        };
+        invokeSrcNameMap: {
+          "checkBluetoothPermission": "done.invoke.scan.checkBluetoothPermission.checking:invocation[0]";
+"checkBluetoothState": "done.invoke.scan.checkBluetoothState.checking:invocation[0]" | "done.invoke.scan.recheckBluetoothState.checking:invocation[0]";
+"checkLocationPermission": "done.invoke.scan.checkingLocationState.checkingPermissionStatus:invocation[0]";
+"checkLocationStatus": "done.invoke.scan.checkingLocationState.checkLocationService:invocation[0]";
+"checkNearByDevicesPermission": "done.invoke.scan.checkNearbyDevicesPermission.checking:invocation[0]";
+"checkStorageAvailability": "done.invoke.scan.checkStorage:invocation[0]";
+"createVp": "done.invoke.scan.reviewing.creatingVp:invocation[0]";
+"disconnect": "done.invoke.scan.clearingConnection:invocation[0]" | "done.invoke.scan.disconnectDevice:invocation[0]";
+"monitorConnection": "done.invoke.scan:invocation[0]";
+"requestBluetooth": "done.invoke.scan.checkBluetoothState.requesting:invocation[0]";
+"requestNearByDevicesPermission": "done.invoke.scan.checkNearbyDevicesPermission.requesting:invocation[0]";
+"requestToEnableLocationPermission": "done.invoke.scan.checkingLocationState.requestToEnableLocation:invocation[0]";
+"sendVc": "done.invoke.scan.reviewing.sendingVc:invocation[0]";
+"startConnection": "done.invoke.scan.connecting:invocation[0]";
+        };
+        missingImplementations: {
+          actions: never;
+          delays: never;
+          guards: never;
+          services: never;
+        };
+        eventsCausingActions: {
+          "clearCreatedVp": "" | "BLE_ERROR" | "DISCONNECT" | "DISMISS" | "RESET" | "SCREEN_BLUR" | "SCREEN_FOCUS" | "xstate.stop";
+"clearReason": "" | "BLE_ERROR" | "DISCONNECT" | "DISMISS" | "RESET" | "SCREEN_BLUR" | "SCREEN_FOCUS" | "xstate.stop";
+"clearUri": "DISCONNECT" | "DISMISS" | "xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection";
+"logFailedVerification": "FACE_INVALID";
+"logShared": "VC_ACCEPTED";
+"openAppPermission": "GOTO_SETTINGS" | "LOCATION_REQUEST";
+"openBluetoothSettings": "GOTO_SETTINGS";
+"registerLoggers": "DISCONNECT" | "DISMISS" | "xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection";
+"removeLoggers": "DISCONNECT" | "DISMISS" | "SCREEN_BLUR" | "xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection" | "xstate.init";
+"resetShouldVerifyPresence": "CANCEL" | "CONNECTED" | "DISMISS" | "RETRY";
+"sendBLEConnectionErrorEvent": "BLE_ERROR";
+"sendScanData": "SCAN";
+"sendVCShareFlowCancelEndEvent": "CANCEL";
+"sendVCShareFlowTimeoutEndEvent": "CANCEL" | "RETRY";
+"sendVcShareSuccessEvent": "VC_ACCEPTED";
+"sendVcSharingStartEvent": "SCAN";
+"setBleError": "BLE_ERROR";
+"setChildRef": "DISCONNECT" | "DISMISS" | "xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection";
+"setCreatedVp": "done.invoke.scan.reviewing.creatingVp:invocation[0]";
+"setLinkCode": "SCAN";
+"setReadyForBluetoothStateCheck": "BLUETOOTH_PERMISSION_ENABLED";
+"setReason": "UPDATE_REASON";
+"setReceiverInfo": "CONNECTED";
+"setSelectedVc": "SELECT_VC";
+"setSenderInfo": "CONNECTED";
+"setShareLogTypeUnverified": "ACCEPT_REQUEST";
+"setShareLogTypeVerified": "FACE_VALID";
+"setUri": "SCAN";
+"storeLoginItem": "done.invoke.QrLogin";
+"storingActivityLog": "STORE_RESPONSE";
+"toggleShouldVerifyPresence": "TOGGLE_USER_CONSENT";
+        };
+        eventsCausingDelays: {
+          "CONNECTION_TIMEOUT": "SCAN";
+"DESTROY_TIMEOUT": "" | "DISMISS" | "LOCATION_ENABLED";
+"SHARING_TIMEOUT": "ACCEPT_REQUEST" | "FACE_VALID" | "done.invoke.scan.reviewing.creatingVp:invocation[0]";
+        };
+        eventsCausingGuards: {
+          "isIOS": "BLUETOOTH_STATE_DISABLED" | "START_PERMISSION_CHECK";
+"isMinimumStorageRequiredForAuditEntryReached": "done.invoke.scan.checkStorage:invocation[0]";
+"isOpenIdQr": "SCAN";
+"isQrLogin": "SCAN";
+"uptoAndroid11": "" | "START_PERMISSION_CHECK";
+        };
+        eventsCausingServices: {
+          "QrLogin": "SCAN";
+"checkBluetoothPermission": "" | "BLUETOOTH_STATE_DISABLED" | "NEARBY_ENABLED" | "START_PERMISSION_CHECK";
+"checkBluetoothState": "" | "APP_ACTIVE";
+"checkLocationPermission": "APP_ACTIVE" | "LOCATION_ENABLED";
+"checkLocationStatus": "" | "LOCATION_REQUEST";
+"checkNearByDevicesPermission": "APP_ACTIVE" | "START_PERMISSION_CHECK";
+"checkStorageAvailability": "RESET" | "SCREEN_FOCUS";
+"createVp": never;
+"disconnect": "" | "DISMISS" | "LOCATION_ENABLED" | "SCREEN_BLUR";
+"monitorConnection": "DISMISS" | "SCREEN_BLUR" | "xstate.init";
+"requestBluetooth": "BLUETOOTH_STATE_DISABLED";
+"requestNearByDevicesPermission": "NEARBY_DISABLED";
+"requestToEnableLocationPermission": "LOCATION_DISABLED";
+"sendVc": "ACCEPT_REQUEST" | "FACE_VALID" | "done.invoke.scan.reviewing.creatingVp:invocation[0]";
+"startConnection": "SCAN";
+        };
+        matchesStates: "bluetoothDenied" | "bluetoothPermissionDenied" | "checkBluetoothPermission" | "checkBluetoothPermission.checking" | "checkBluetoothPermission.enabled" | "checkBluetoothState" | "checkBluetoothState.checking" | "checkBluetoothState.enabled" | "checkBluetoothState.requesting" | "checkNearbyDevicesPermission" | "checkNearbyDevicesPermission.checking" | "checkNearbyDevicesPermission.enabled" | "checkNearbyDevicesPermission.requesting" | "checkStorage" | "checkingLocationState" | "checkingLocationState.checkLocationService" | "checkingLocationState.checkingPermissionStatus" | "checkingLocationState.denied" | "checkingLocationState.disabled" | "checkingLocationState.requestToEnableLocation" | "clearingConnection" | "connecting" | "connecting.inProgress" | "connecting.timeout" | "disconnectDevice" | "disconnected" | "findingConnection" | "handlingBleError" | "inactive" | "invalid" | "nearByDevicesPermissionDenied" | "recheckBluetoothState" | "recheckBluetoothState.checking" | "recheckBluetoothState.enabled" | "restrictSharingVc" | "reviewing" | "reviewing.accepted" | "reviewing.cancelling" | "reviewing.creatingVp" | "reviewing.invalidIdentity" | "reviewing.navigatingToHome" | "reviewing.rejected" | "reviewing.selectingVc" | "reviewing.sendingVc" | "reviewing.sendingVc.inProgress" | "reviewing.sendingVc.sent" | "reviewing.sendingVc.timeout" | "reviewing.verifyingIdentity" | "showQrLogin" | "showQrLogin.idle" | "showQrLogin.navigatingToHistory" | "showQrLogin.storing" | "startPermissionCheck" | { "checkBluetoothPermission"?: "checking" | "enabled";
+"checkBluetoothState"?: "checking" | "enabled" | "requesting";
+"checkNearbyDevicesPermission"?: "checking" | "enabled" | "requesting";
+"checkingLocationState"?: "checkLocationService" | "checkingPermissionStatus" | "denied" | "disabled" | "requestToEnableLocation";
+"connecting"?: "inProgress" | "timeout";
+"recheckBluetoothState"?: "checking" | "enabled";
+"reviewing"?: "accepted" | "cancelling" | "creatingVp" | "invalidIdentity" | "navigatingToHome" | "rejected" | "selectingVc" | "sendingVc" | "verifyingIdentity" | { "sendingVc"?: "inProgress" | "sent" | "timeout"; };
+"showQrLogin"?: "idle" | "navigatingToHistory" | "storing"; };
+        tags: never;
+      }
+  

--- a/machines/settings.typegen.ts
+++ b/machines/settings.typegen.ts
@@ -1,64 +1,49 @@
-// This file was automatically generated. Edits will be overwritten
 
-export interface Typegen0 {
-  '@@xstate/typegen': true;
-  internalEvents: {
-    'done.invoke.settings.resetInjiProps:invocation[0]': {
-      type: 'done.invoke.settings.resetInjiProps:invocation[0]';
-      data: unknown;
-      __tip: 'See the XState TS docs to learn how to strongly type this.';
-    };
-    'error.platform.settings.resetInjiProps:invocation[0]': {
-      type: 'error.platform.settings.resetInjiProps:invocation[0]';
-      data: unknown;
-    };
-    'xstate.init': {type: 'xstate.init'};
-  };
-  invokeSrcNameMap: {
-    resetInjiProps: 'done.invoke.settings.resetInjiProps:invocation[0]';
-  };
-  missingImplementations: {
-    actions: never;
-    delays: never;
-    guards: never;
-    services: never;
-  };
-  eventsCausingActions: {
-    requestStoredContext: 'xstate.init';
-    resetCredentialRegistry: 'CANCEL' | 'UPDATE_MIMOTO_HOST';
-    setContext: 'STORE_RESPONSE';
-    storeContext:
-      | 'ACCEPT_HARDWARE_SUPPORT_NOT_EXISTS'
-      | 'STORE_RESPONSE'
-      | 'TOGGLE_BIOMETRIC_UNLOCK'
-      | 'UPDATE_ESIGNET_HOST'
-      | 'UPDATE_NAME'
-      | 'UPDATE_VC_LABEL'
-      | 'done.invoke.settings.resetInjiProps:invocation[0]';
-    toggleBiometricUnlock: 'TOGGLE_BIOMETRIC_UNLOCK';
-    updateCredentialRegistry: 'done.invoke.settings.resetInjiProps:invocation[0]';
-    updateCredentialRegistryResponse: 'error.platform.settings.resetInjiProps:invocation[0]';
-    updateCredentialRegistrySuccess: 'done.invoke.settings.resetInjiProps:invocation[0]';
-    updateDefaults: 'STORE_RESPONSE';
-    updateEsignetHostUrl: 'UPDATE_ESIGNET_HOST';
-    updateName: 'UPDATE_NAME';
-    updatePartialDefaults: 'STORE_RESPONSE';
-    updateUserShownWithHardwareKeystoreNotExists: 'ACCEPT_HARDWARE_SUPPORT_NOT_EXISTS';
-    updateVcLabel: 'UPDATE_VC_LABEL';
-  };
-  eventsCausingDelays: {};
-  eventsCausingGuards: {
-    hasData: 'STORE_RESPONSE';
-    hasPartialData: 'STORE_RESPONSE';
-  };
-  eventsCausingServices: {
-    resetInjiProps: 'UPDATE_MIMOTO_HOST';
-  };
-  matchesStates:
-    | 'idle'
-    | 'init'
-    | 'resetInjiProps'
-    | 'showInjiTourGuide'
-    | 'storingDefaults';
-  tags: never;
-}
+  // This file was automatically generated. Edits will be overwritten
+
+  export interface Typegen0 {
+        '@@xstate/typegen': true;
+        internalEvents: {
+          "done.invoke.settings.resetInjiProps:invocation[0]": { type: "done.invoke.settings.resetInjiProps:invocation[0]"; data: unknown; __tip: "See the XState TS docs to learn how to strongly type this." };
+"error.platform.settings.resetInjiProps:invocation[0]": { type: "error.platform.settings.resetInjiProps:invocation[0]"; data: unknown };
+"xstate.init": { type: "xstate.init" };
+        };
+        invokeSrcNameMap: {
+          "resetInjiProps": "done.invoke.settings.resetInjiProps:invocation[0]";
+        };
+        missingImplementations: {
+          actions: never;
+          delays: never;
+          guards: never;
+          services: never;
+        };
+        eventsCausingActions: {
+          "requestStoredContext": "xstate.init";
+"resetCredentialRegistryResponse": "CANCEL" | "UPDATE_HOST";
+"setContext": "STORE_RESPONSE";
+"storeContext": "ACCEPT_HARDWARE_SUPPORT_NOT_EXISTS" | "STORE_RESPONSE" | "TOGGLE_BIOMETRIC_UNLOCK" | "UPDATE_HOST" | "UPDATE_NAME" | "UPDATE_VC_LABEL" | "done.invoke.settings.resetInjiProps:invocation[0]";
+"toggleBiometricUnlock": "TOGGLE_BIOMETRIC_UNLOCK";
+"updateCredentialRegistry": "done.invoke.settings.resetInjiProps:invocation[0]";
+"updateCredentialRegistryResponse": "error.platform.settings.resetInjiProps:invocation[0]";
+"updateCredentialRegistrySuccess": "done.invoke.settings.resetInjiProps:invocation[0]";
+"updateDefaults": "STORE_RESPONSE";
+"updateEsignetHostUrl": "UPDATE_HOST";
+"updateName": "UPDATE_NAME";
+"updatePartialDefaults": "STORE_RESPONSE";
+"updateUserShownWithHardwareKeystoreNotExists": "ACCEPT_HARDWARE_SUPPORT_NOT_EXISTS";
+"updateVcLabel": "UPDATE_VC_LABEL";
+        };
+        eventsCausingDelays: {
+          
+        };
+        eventsCausingGuards: {
+          "hasData": "STORE_RESPONSE";
+"hasPartialData": "STORE_RESPONSE";
+        };
+        eventsCausingServices: {
+          "resetInjiProps": "UPDATE_HOST";
+        };
+        matchesStates: "idle" | "init" | "resetInjiProps" | "showInjiTourGuide" | "storingDefaults";
+        tags: never;
+      }
+  

--- a/shared/commonprops/commonProps.ts
+++ b/shared/commonprops/commonProps.ts
@@ -2,6 +2,13 @@ import {configure} from '@iriscan/biometric-sdk-react-native';
 import {changeCrendetialRegistry} from '../constants';
 import {CACHED_API} from '../api';
 import {faceMatchConfig} from '../commonUtil';
+import {
+  getErrorEventData,
+  getImpressionEventData,
+  sendErrorEvent,
+  sendImpressionEvent,
+} from '../telemetry/TelemetryUtils';
+import {TelemetryConstants} from '../telemetry/TelemetryConstants';
 
 export const COMMON_PROPS_KEY: string =
   'CommonPropsKey-' + '6964d04a-9268-11ed-a1eb-0242ac120002';
@@ -16,6 +23,7 @@ export default async function getAllConfigurations(
 
 export async function downloadModel() {
   try {
+    console.log('restart Face model init');
     var injiProp = await getAllConfigurations();
     const maxRetryStr = injiProp.modelDownloadMaxRetry;
     const maxRetry = parseInt(maxRetryStr);
@@ -27,11 +35,29 @@ export async function downloadModel() {
         var result = await configure(config);
         console.log('model download result is = ' + result);
         if (result) {
+          sendImpressionEvent(
+            getImpressionEventData(
+              TelemetryConstants.FlowType.faceModelInit,
+              TelemetryConstants.EndEventStatus.success,
+            ),
+          );
           break;
         }
+        sendErrorEvent(
+          getErrorEventData(
+            TelemetryConstants.FlowType.faceModelInit,
+            TelemetryConstants.EndEventStatus.failure,
+          ),
+        );
       }
     }
   } catch (error) {
+    sendErrorEvent(
+      getErrorEventData(
+        TelemetryConstants.FlowType.faceModelInit,
+        TelemetryConstants.EndEventStatus.failure,
+      ),
+    );
     console.log(error);
   }
 }

--- a/shared/commonprops/commonProps.ts
+++ b/shared/commonprops/commonProps.ts
@@ -38,24 +38,29 @@ export async function downloadModel() {
           sendImpressionEvent(
             getImpressionEventData(
               TelemetryConstants.FlowType.faceModelInit,
-              TelemetryConstants.EndEventStatus.success,
+              TelemetryConstants.Screens.home,
+              {status: TelemetryConstants.EndEventStatus.success},
             ),
           );
           break;
+        } else if (!result && counter === maxRetry - 1) {
+          sendErrorEvent(
+            getErrorEventData(
+              TelemetryConstants.FlowType.faceModelInit,
+              TelemetryConstants.ErrorId.failure,
+              TelemetryConstants.ErrorMessage.faceModelInitFailed,
+            ),
+          );
         }
-        sendErrorEvent(
-          getErrorEventData(
-            TelemetryConstants.FlowType.faceModelInit,
-            TelemetryConstants.EndEventStatus.failure,
-          ),
-        );
       }
     }
   } catch (error) {
     sendErrorEvent(
       getErrorEventData(
         TelemetryConstants.FlowType.faceModelInit,
-        TelemetryConstants.EndEventStatus.failure,
+        TelemetryConstants.ErrorId.failure,
+        TelemetryConstants.ErrorMessage.faceModelInitFailed,
+        error,
       ),
     );
     console.log(error);

--- a/shared/telemetry/TelemetryConstants.js
+++ b/shared/telemetry/TelemetryConstants.js
@@ -1,6 +1,7 @@
 export const TelemetryConstants = {
   FlowType: Object.freeze({
     vcDownload: 'VC Download',
+    faceModelInit: 'Face SDK initialize',
     qrLogin: 'QR Login',
     senderVcShare: 'Sender VC Share',
     receiverVcShare: 'Receiver VC Share',

--- a/shared/telemetry/TelemetryConstants.js
+++ b/shared/telemetry/TelemetryConstants.js
@@ -25,6 +25,7 @@ export const TelemetryConstants = {
   }),
 
   ErrorMessage: Object.freeze({
+    faceModelInitFailed: 'Face model init failed',
     authenticationCancelled: 'Authentication Cancelled',
     passcodeDidNotMatch: 'Pass code did not match',
     resendOtp: 'Otp is requested multiple times',
@@ -38,6 +39,7 @@ export const TelemetryConstants = {
   }),
 
   ErrorId: Object.freeze({
+    failure: 'FAILURE',
     mismatch: 'MISMATCH',
     doesNotExist: 'DOES_NOT_EXIST',
     userCancel: 'USER_CANCEL',


### PR DESCRIPTION
# Summary

(Q) What we know so far?
(A) The crash is possible on Android & iOS if the Face SDK is not initialized, there could be other reasons as well hence we are going to log an event in Telemetry and observe if a crash still exists.

(Q) Have we verified that the app crashes?
(A) Yes, I have disabled the download of face model and tried to do a Share with Selfie and a Online QR Login on Android & iOS and in both platforms the phones have crashed.

(Q) Could there be other reasons for the crash?
(A) Yes, I’ve observed one of the issue and tried to fix it and I’ll be adding telemetry events to see if the crash still happens when the face SDK model is initialized correctly.
