### PR TITLE
fix: cancel download popup & tuvali version

### DIFF
--- a/screens/Home/MyVcs/AddVcModalController.ts
+++ b/screens/Home/MyVcs/AddVcModalController.ts
@@ -7,6 +7,7 @@ import {
   selectIsRequestingCredential,
   selectOtpError,
   selectIsAcceptingIdInput,
+  selectIsCancellingDownload,
 } from './AddVcModalMachine';
 
 export function useAddVcModal({service}: AddVcModalProps) {
@@ -17,6 +18,7 @@ export function useAddVcModal({service}: AddVcModalProps) {
 
     isAcceptingUinInput: useSelector(service, selectIsAcceptingIdInput),
     isAcceptingOtpInput: useSelector(service, selectIsAcceptingOtpInput),
+    isDownloadCancelled: useSelector(service, selectIsCancellingDownload),
 
     INPUT_OTP: (otp: string) => service.send(AddVcModalEvents.INPUT_OTP(otp)),
 

--- a/shared/GlobalVariables.ts
+++ b/shared/GlobalVariables.ts
@@ -5,22 +5,16 @@ import {APP_ID_LENGTH} from './constants';
 const dependencies = require('../package-lock.json').dependencies;
 
 function getTuvaliPackageDetails() {
-  let packageVersion, packageCommitId;
-
+  let packageVersion;
   Object.keys(dependencies).forEach(dependencyName => {
     const dependencyData = dependencies[dependencyName];
-
     if (dependencyName == '@mosip/tuvali') {
-      packageVersion = dependencyData.from
-        ? dependencyData.from.split('#')[1]
+      packageVersion = dependencyData?.version
+        ? dependencyData.version
         : 'unknown';
-
-      if (packageVersion != 'unknown') {
-        packageCommitId = dependencyData.version.split('#')[1].substring(0, 7);
-      }
     }
   });
-  return {packageVersion, packageCommitId};
+  return {packageVersion};
 }
 export class __AppId {
   private static value: string;
@@ -36,16 +30,12 @@ export class __AppId {
 export class __TuvaliVersion {
   private static packageDetails = getTuvaliPackageDetails();
 
-  public static getPackageCommitId(): string {
-    return __TuvaliVersion.packageDetails.packageCommitId;
-  }
-
   public static getpackageVersion(): string {
     return __TuvaliVersion.packageDetails.packageVersion;
   }
 
   public static getValue(): string {
-    return this.getpackageVersion() + '-' + this.getPackageCommitId();
+    return this.getpackageVersion();
   }
 }
 export class __InjiVersion {


### PR DESCRIPTION
Changes include
1. fix - download cancel popup not shown when close icon is pressed in OTP modal while downloading VC
2. fix - Tuvali version not shown in About Inji page