### PR TITLE
INJI-512: The navigation button to go back from the ID details page provided as per wire frame.

### DIFF
--- a/screens/Home/ViewVcModal.tsx
+++ b/screens/Home/ViewVcModal.tsx
@@ -18,6 +18,7 @@ import {
   sendErrorEvent,
 } from '../../shared/telemetry/TelemetryUtils';
 import {TelemetryConstants} from '../../shared/telemetry/TelemetryConstants';
+import {Icon} from 'react-native-elements';
 
 export const ViewVcModal: React.FC<ViewVcModalProps> = props => {
   const {t} = useTranslation('ViewVcModal');
@@ -57,9 +58,10 @@ export const ViewVcModal: React.FC<ViewVcModalProps> = props => {
   return (
     <Modal
       isVisible={props.isVisible}
-      onDismiss={props.onDismiss}
+      arrowLeft={<Icon name={''} />}
       headerTitle={t('title')}
       testID="idDetailsHeader"
+      onDismiss={props.onDismiss}
       headerElevation={2}>
       {controller.isBindingSuccess && (
         <BannerNotification
@@ -121,7 +123,7 @@ export const ViewVcModal: React.FC<ViewVcModalProps> = props => {
       />
 
       <MessageOverlay
-        testID='walletBindingError'
+        testID="walletBindingError"
         isVisible={controller.isBindingError}
         title={controller.walletBindingError}
         onButtonPress={() => {

--- a/screens/Home/ViewVcModal.tsx
+++ b/screens/Home/ViewVcModal.tsx
@@ -58,9 +58,9 @@ export const ViewVcModal: React.FC<ViewVcModalProps> = props => {
   return (
     <Modal
       isVisible={props.isVisible}
-      arrowLeft={<Icon name={''} />}
-      headerTitle={t('title')}
       testID="idDetailsHeader"
+      arrowLeft={true}
+      headerTitle={t('title')}
       onDismiss={props.onDismiss}
       headerElevation={2}>
       {controller.isBindingSuccess && (

--- a/screens/QrLogin/MyBindedVcs.tsx
+++ b/screens/QrLogin/MyBindedVcs.tsx
@@ -19,7 +19,7 @@ export const MyBindedVcs: React.FC<MyBindedVcsProps> = props => {
   return (
     <Modal
       isVisible={controller.isShowingVcList}
-      arrowLeft={<Icon name={''} />}
+      arrowLeft={true}
       headerTitle={t('selectId')}
       headerElevation={5}
       onDismiss={() => {

--- a/screens/QrLogin/QrConsent.tsx
+++ b/screens/QrLogin/QrConsent.tsx
@@ -17,7 +17,7 @@ export const QrConsent: React.FC<QrConsentProps> = props => {
   return (
     <Modal
       isVisible={props.isVisible}
-      arrowLeft={<Icon name={''} />}
+      arrowLeft={true}
       headerTitle={t('consent')}
       headerElevation={5}
       onDismiss={props.onCancel}>

--- a/screens/QrLogin/QrLoginSuccessMessage.tsx
+++ b/screens/QrLogin/QrLoginSuccessMessage.tsx
@@ -16,7 +16,7 @@ export const QrLoginSuccess: React.FC<QrLoginSuccessProps> = props => {
   return (
     <Modal
       isVisible={controller.isVerifyingSuccesful}
-      arrowLeft={<Icon name={''} />}
+      arrowLeft={true}
       headerTitle={t('status')}
       headerElevation={5}
       onDismiss={controller.DISMISS}>

--- a/screens/Settings/ReceivedCardsModal.tsx
+++ b/screens/Settings/ReceivedCardsModal.tsx
@@ -16,9 +16,9 @@ export const ReceivedCardsModal: React.FC<ReceivedCardsProps> = ({
   const {t} = useTranslation('ReceivedVcsTab');
   return (
     <Modal
-      testID='receivedCardsModal'
+      testID="receivedCardsModal"
       isVisible={isVisible}
-      arrowLeft={<Icon name={''} />}
+      arrowLeft={true}
       headerTitle={t('header')}
       headerElevation={2}
       onDismiss={onDismiss}>

--- a/screens/Settings/SettingScreen.tsx
+++ b/screens/Settings/SettingScreen.tsx
@@ -71,7 +71,7 @@ export const SettingScreen: React.FC<
       <Modal
         testID="settingsScreen"
         isVisible={controller.isVisible}
-        arrowLeft={<Icon name={''} />}
+        arrowLeft={true}
         headerTitle={t('header')}
         headerElevation={2}
         onDismiss={controller.TOGGLE_SETTINGS}>

--- a/screens/VerifyIdentityOverlay.tsx
+++ b/screens/VerifyIdentityOverlay.tsx
@@ -26,7 +26,7 @@ export const VerifyIdentityOverlay: React.FC<
   return (
     <Modal
       isVisible={props.isVisible}
-      arrowLeft={<Icon name={''} />}
+      arrowLeft={true}
       headerTitle={t('faceAuth')}
       onDismiss={props.onCancel}>
       <Column


### PR DESCRIPTION
**[INJI-512](https://mosip.atlassian.net/browse/INJI-512)**:  
The navigation button to go back from the ID details page is missing, implemented as per wireframe provided.
 
**[Respective Screen Record](https://github.com/mosip/inji/assets/106086523/4d2a645f-76b7-4c2b-8983-182c6d3548d1)**



[INJI-512]: https://mosip.atlassian.net/browse/INJI-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ