### PR TITLE
[Inji 597] use npm sonar-scanner package to perform sonar qube analysis on inji code

### DIFF
--- a/.github/workflows/internal-build.yml
+++ b/.github/workflows/internal-build.yml
@@ -166,14 +166,14 @@ jobs:
   #     SLACK_WEBHOOK_URL: '${{ secrets.SLACK_WEBHOOK }}'
 
   sonar-check:
-    uses: tw-mosip/kattu/.github/workflows/gradlew-sonar-analysis.yml@inji-add-release-keystore-step-for-sonar
+    uses: tw-mosip/kattu/.github/workflows/npm-sonar-analysis.yml@inji-add-release-keystore-step-for-sonar
     with:
       SERVICE_LOCATION: '.'
       ANDROID_LOCATION: 'android'
       RELEASE_KEYSTORE_ALIAS: androidreleasekey
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      SONAR_ORGANIZATION: ${{ secrets.ORG_KEY }}
+      ORG_KEY: ${{ secrets.ORG_KEY }}
       SLACK_WEBHOOK_URL: '${{ secrets.SLACK_WEBHOOK }}'
       ANDROID_KEYSTORE_FILE: ${{ secrets.INJI_ANDROID_RELEASE_KEYSTORE }}
       RELEASE_KEYSTORE_PASSWORD: '${{ secrets.INJI_ANDROID_RELEASE_STOREPASS }}'

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build:android:mosip": "cd android && ./gradlew :app:assembleResidentappRelease && cd ..",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "test": "jest",
-    "postinstall": "patch-package && npm run jetify && sh tools/talisman/talisman-precommit.sh"
+    "postinstall": "patch-package && npm run jetify && sh tools/talisman/talisman-precommit.sh",
+    "sonar": "sonar-scanner",
+    "build": "cd android && ./gradlew :app:assembleResidentapp lint -Dlint.baselines.continue=true && cd .. && jest --coverage"
   },
   "dependencies": {
     "@digitalbazaar/ed25519-signature-2018": "digitalbazaar/ed25519-signature-2018",


### PR DESCRIPTION
- gradlew sonar analysis file of kattu which we were using is performing the sonar qube analysis on the android native code but we wanted it to be applied on inji typescript files so using npm-sonar-analysis.yml file of kattu which is using sonar-scanner npm package