### PR TITLE
[INJI-714] fix app relaunch in scan & receive screen

### DIFF
--- a/android/app/src/main/java/io/mosip/residentapp/MainActivity.java
+++ b/android/app/src/main/java/io/mosip/residentapp/MainActivity.java
@@ -89,28 +89,6 @@ public class MainActivity extends ReactActivity {
     return true;
   }
 
-  /**
-   * Handles user acceptance (or denial) of our permission request.
-   */
-  @CallSuper
-  @Override
-  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-    super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-
-    if (requestCode != REQUEST_CODE_REQUIRED_PERMISSIONS) {
-      return;
-    }
-
-    for (int grantResult : grantResults) {
-      if (grantResult == PackageManager.PERMISSION_DENIED) {
-        // Toast.makeText(this, R.string.error_missing_permissions, Toast.LENGTH_LONG).show();
-        // connectButton.setEnabled(false);
-        Log.d("Main", "Denied");
-        return;
-      }
-    }
-    recreate();
-  }
 
     /**
    * Returns the instance of the {@link ReactActivityDelegate}. Here we use a util class {@link


### PR DESCRIPTION
App relaunchs when nearby permissions is allowed in scan screen and navigated to receive screen and vice versa. This was happening due to our custom logic handled in MainActivity onRequestPermissionsResult performing activity recreation when requestCode is  1 & is not denied. The requestCode for BLUETOOTH_SCAN (in Share screen) permission grant result is 1 (after giving nearby devices permission in receive screen) which satisfied the condition of app relaunch. For this reason onRequestPermissionsResult method has been removed.