### PR TITLE
INJIMOB-741: Fixed receive card header is fully in caps

### DIFF
--- a/screens/Request/RequestLayout.tsx
+++ b/screens/Request/RequestLayout.tsx
@@ -55,7 +55,7 @@ export const RequestLayout: React.FC = () => {
           name={REQUEST_ROUTES.RequestScreen}
           component={RequestScreen}
           options={{
-            title: t('receiveCard').toUpperCase(),
+            title: t('receiveCard'),
           }}
         />
       </RequestStack.Navigator>


### PR DESCRIPTION
**[INJIMOB-741](https://mosip.atlassian.net/browse/INJIMOB-741)**:  Android receive card header is fully in caps.

[INJIMOB-741]: https://mosip.atlassian.net/browse/INJIMOB-741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ