### PR TITLE
[INJIMOB-531] send base64 encode data to encrypt to avoid data truncation

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,8 +1,8 @@
 fileignoreconfig:
   - filename: package.json
-    checksum: 4770aabfda162fbc0b9a8c53d7dee483ce29b82c6cd3e17e81e3e628d93dbadc
+    checksum: 730263252adbe53cde58fb0b6988e519e766fe0f89a7b8cd261a1e5e5e598328
   - filename: package-lock.json
-    checksum: 8f9e6bdd4cc0fcbd979455d97d6313e60dda3da1771bef471e53d4efaac9f24d
+    checksum: 4e09116d21aa8def35ffe234dabec6abc668f15183e172764df2216adb0d2ca1
   - filename: lib/jsonld-signatures/suites/ed255192018/ed25519.ts
     checksum: 493b6e31144116cb612c24d98b97d8adcad5609c0a52c865a6847ced0a0ddc3a
   - filename: components/PasscodeVerify.tsx
@@ -40,7 +40,7 @@ fileignoreconfig:
   - filename: screens/Issuers/IssuersScreen.tsx
     checksum: 9c53e3770dbefe26e0de67ee4b7d5cc9c52d9823cbb136a1a5104dcb0a101071
   - filename: ios/Podfile.lock
-    checksum: 0e4fce1a146e882a6cabbc3e78ae2c35fe58f1dee956c7d9d85902504135bc92
+    checksum: 3d5c2bd7979bbe75af3b321967257ccc8310027391fd815daa3beae4e122face
   - filename: shared/commonUtil.ts
     checksum: 4a53bb615f2ea0fbf687bd7027c4c246e819dd88bc273941ed611e763d9d2356
   - filename: screens/Home/MyVcs/GetIdInputModal.tsx
@@ -178,8 +178,6 @@ fileignoreconfig:
     checksum: bbc69143bd37d065bba3800396301db5a0318e8b7ba51ecd49142dda68783a01
   - filename: machines/backupAndRestore/backupAndRestoreSetup.typegen.ts
     checksum: 8203331f1628e01faa5e553e749372be278b477ca2d34a0cdafee1438248fb3c
-  - filename: package-lock.json
-    checksum: c1e628b384b35598c9741401f4e2ad0f5cd3e9b3dff0bee23a389f0590681593
   - filename: injitest/README.md
     checksum: 82974a6b9363512472272245e9b433f92e63377e58ba306980876b745181a09c
   - filename: machines/backupAndRestore/backup.ts
@@ -196,8 +194,6 @@ fileignoreconfig:
     checksum: 85e92ddec56da8dcdd28b5a29dfabd88dd0435e619f822488bc4e19b83872289
   - filename: machines/backupAndRestore/backupAndRestoreSetup.typegen.ts
     checksum: dd5dc9c42800328c268f3e6d6c96a16e9686dbfa59735e721250dae3ce37e009
-  - filename: ios/Podfile.lock
-    checksum: 235f31beadf3833ac763ed1b79e00f588e56990873806627b5abf8643992336a
   - filename: machines/backupAndRestore/backupAndRestoreSetup.typegen.ts
     checksum: dd5dc9c42800328c268f3e6d6c96a16e9686dbfa59735e721250dae3ce37e009
   - filename: injitest/src/main/java/inji/pages/BackupAndRestorePage.java

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -512,7 +512,7 @@ PODS:
   - RNZipArchive/Core (6.1.0):
     - React-Core
     - SSZipArchive (~> 2.2)
-  - secure-keystore (0.1.6):
+  - secure-keystore (0.1.7):
     - React-Core
   - SSZipArchive (2.4.3)
   - TensorFlowLiteC (2.12.0):
@@ -928,7 +928,7 @@ SPEC CHECKSUMS:
   RNSecureRandom: 07efbdf2cd99efe13497433668e54acd7df49fef
   RNSVG: 07dbd870b0dcdecc99b3a202fa37c8ca163caec2
   RNZipArchive: ef9451b849c45a29509bf44e65b788829ab07801
-  secure-keystore: 78bf735f42b9d19418568dadbb92712c19a5812e
+  secure-keystore: 3bc262bc91c5fbcfea92a8d0fd59c1b8b8ababee
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef
   TensorFlowLiteC: 20785a69299185a379ba9852b6625f00afd7984a
   TensorFlowLiteObjC: 9a46a29a76661c513172cfffd3bf712b11ef25c3

--- a/machines/store.ts
+++ b/machines/store.ts
@@ -36,6 +36,7 @@ import {
   getErrorEventData,
 } from '../shared/telemetry/TelemetryUtils';
 import RNSecureKeyStore from 'react-native-secure-key-store';
+import {Buffer} from 'buffer';
 
 export const keyinvalidatedString =
   'Key Invalidated due to biometric enrollment';
@@ -298,9 +299,11 @@ export const storeMachine =
           const hasSetCredentials = SecureKeystore.hasAlias(ENCRYPTION_ID);
           if (hasSetCredentials) {
             try {
+              const base64EncodedString =
+                Buffer.from('Dummy').toString('base64');
               await SecureKeystore.encryptData(
                 DUMMY_KEY_FOR_BIOMETRIC_ALIAS,
-                'Dummy',
+                base64EncodedString,
               );
             } catch (e) {
               sendErrorEvent(getErrorEventData('ENCRYPTION', '', e));

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@expo-google-fonts/inter": "^0.2.3",
         "@expo/metro-config": "~0.10.0",
         "@iriscan/biometric-sdk-react-native": "0.2.6",
-        "@mosip/secure-keystore": "^0.1.6",
+        "@mosip/secure-keystore": "^0.1.7",
         "@mosip/tuvali": "^0.4.9",
         "@react-native-clipboard/clipboard": "^1.10.0",
         "@react-native-community/netinfo": "9.3.7",
@@ -6144,9 +6144,9 @@
       }
     },
     "node_modules/@mosip/secure-keystore": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@mosip/secure-keystore/-/secure-keystore-0.1.6.tgz",
-      "integrity": "sha512-f7KsofyLXWHPy0Day5ejIXzXYGZxEss8tKOCKICaTOtrtsPEmPVnkOwwkqDgV4B9FZnux0JCUsPTZdUrEHchnA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@mosip/secure-keystore/-/secure-keystore-0.1.7.tgz",
+      "integrity": "sha512-Yo9pCj1do8mKkwMkhRVbnf0cqOQaD3EJlMgcM8OyEedvB/dA5qQKJ2nDt7SkA+Rjnl1XHmvv6qAmLD1xuOD8kQ==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -33961,9 +33961,9 @@
       }
     },
     "@mosip/secure-keystore": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@mosip/secure-keystore/-/secure-keystore-0.1.6.tgz",
-      "integrity": "sha512-f7KsofyLXWHPy0Day5ejIXzXYGZxEss8tKOCKICaTOtrtsPEmPVnkOwwkqDgV4B9FZnux0JCUsPTZdUrEHchnA==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@mosip/secure-keystore/-/secure-keystore-0.1.7.tgz",
+      "integrity": "sha512-Yo9pCj1do8mKkwMkhRVbnf0cqOQaD3EJlMgcM8OyEedvB/dA5qQKJ2nDt7SkA+Rjnl1XHmvv6qAmLD1xuOD8kQ==",
       "requires": {}
     },
     "@mosip/tuvali": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@expo-google-fonts/inter": "^0.2.3",
     "@expo/metro-config": "~0.10.0",
     "@iriscan/biometric-sdk-react-native": "0.2.6",
-    "@mosip/secure-keystore": "^0.1.6",
+    "@mosip/secure-keystore": "^0.1.7",
     "@mosip/tuvali": "^0.4.9",
     "@react-native-clipboard/clipboard": "^1.10.0",
     "@react-native-community/netinfo": "9.3.7",

--- a/shared/cryptoutil/cryptoUtil.ts
+++ b/shared/cryptoutil/cryptoUtil.ts
@@ -6,6 +6,7 @@ import {BiometricCancellationError} from '../error/BiometricCancellationError';
 import {EncryptedOutput} from './encryptedOutput';
 import {getErrorEventData, sendErrorEvent} from '../telemetry/TelemetryUtils';
 import {TelemetryConstants} from '../telemetry/TelemetryConstants';
+import {Buffer} from 'buffer';
 
 // 5min
 export const AUTH_TIMEOUT = 5 * 60;
@@ -114,7 +115,8 @@ export async function encryptJson(
     if (!isHardwareKeystoreExists) {
       return encryptWithForge(data, encryptionKey).toString();
     }
-    return await SecureKeystore.encryptData(ENCRYPTION_ID, data);
+    const base64EncodedString = Buffer.from(data).toString('base64');
+    return await SecureKeystore.encryptData(ENCRYPTION_ID, base64EncodedString);
   } catch (error) {
     console.error('error while encrypting:', error);
     if (error.toString().includes(BIOMETRIC_CANCELLED)) {


### PR DESCRIPTION
When we pass data from a react native app with <part1>\x00<part2> value, any data post the \x00 gets truncated (i.e., part2 is trimmed off). This happens most likely with the react native bridge. To avoid this issue of truncation, we are required to pass the data as base64 encoded string and secure-keystore module will perform decoding before processing for encryption.

Pre-requisite: secure-keystore module needs to be updated to recent version before merging this PR