### PR TITLE
[INJIMOB-842]: mock the verification of vc only for range error for MOSIP VC.

### DIFF
--- a/machines/VCItemMachine/EsignetMosipVCItem/EsignetMosipVCItemMachine.ts
+++ b/machines/VCItemMachine/EsignetMosipVCItem/EsignetMosipVCItemMachine.ts
@@ -1,4 +1,4 @@
-import {assign, ErrorPlatformEvent, EventFrom, send, StateFrom} from 'xstate';
+import {assign, ErrorPlatformEvent, EventFrom, send} from 'xstate';
 import {createModel} from 'xstate/lib/model';
 import {AppServices} from '../../../shared/GlobalContext';
 import {VCMetadata} from '../../../shared/VCMetadata';
@@ -38,6 +38,7 @@ import {BackupEvents} from '../../backupAndRestore/backup';
 import Cloud, {
   isSignedInResult,
 } from '../../../shared/CloudBackupAndRestoreUtils';
+import {getMosipIdentifier} from '../../../shared/commonUtil';
 
 const model = createModel(
   {
@@ -274,9 +275,9 @@ export const EsignetMosipVCItemMachine = model.createMachine(
             {
               target: 'updatingPrivateKey',
               /*The walletBindingResponse is used for conditional rendering in wallet binding.
-                However, it wrongly considers activation as successful even when there's an error
-                in updatingPrivateKey state. So created a temporary context variable to store the binding
-                response and use it in updatingPrivateKey state*/
+                              However, it wrongly considers activation as successful even when there's an error
+                              in updatingPrivateKey state. So created a temporary context variable to store the binding
+                              response and use it in updatingPrivateKey state*/
               actions: 'setTempWalletBindingResponse',
             },
           ],
@@ -830,10 +831,9 @@ export const EsignetMosipVCItemMachine = model.createMachine(
           {
             requestTime: String(new Date().toISOString()),
             request: {
-              individualId: context.verifiableCredential.credential
-                .credentialSubject.VID
-                ? context.verifiableCredential.credential.credentialSubject.VID
-                : context.verifiableCredential.credential.credentialSubject.UIN,
+              individualId: getMosipIdentifier(
+                context.verifiableCredential.credential.credentialSubject,
+              ),
               otpChannels: ['EMAIL', 'PHONE'],
             },
           },

--- a/shared/VCMetadata.ts
+++ b/shared/VCMetadata.ts
@@ -1,19 +1,19 @@
 import {VC, VcIdType} from '../types/VC/ExistingMosipVC/vc';
 import {Issuers, Protocols} from './openId4VCI/Utils';
+import {getMosipIdentifier} from './commonUtil';
 
 const VC_KEY_PREFIX = 'VC';
 const VC_ITEM_STORE_KEY_REGEX = '^VC_[a-zA-Z0-9_-]+$';
 
 export class VCMetadata {
+  static vcKeyRegExp = new RegExp(VC_ITEM_STORE_KEY_REGEX);
   idType: VcIdType | string = '';
   requestId = '';
   isPinned = false;
   id: string = '';
-
   issuer?: string = '';
   protocol?: string = '';
   timestamp?: string = '';
-  static vcKeyRegExp = new RegExp(VC_ITEM_STORE_KEY_REGEX);
 
   constructor({
     idType = '',
@@ -101,9 +101,9 @@ export const getVCMetadata = context => {
     requestId: requestId ? requestId : null,
     issuer: issuer,
     protocol: protocol,
-    id: context.verifiableCredential?.credential.credentialSubject.UIN
-      ? context.verifiableCredential?.credential.credentialSubject.UIN
-      : context.verifiableCredential?.credential.credentialSubject.VID,
+    id: getMosipIdentifier(
+      context.verifiableCredential?.credential.credentialSubject,
+    ),
     timestamp: context.timestamp ?? '',
   });
 };

--- a/shared/commonUtil.ts
+++ b/shared/commonUtil.ts
@@ -4,8 +4,9 @@ import {getDeviceNameSync} from 'react-native-device-info';
 import {GOOGLE_DRIVE_NAME, ICLOUD_DRIVE_NAME, isAndroid} from './constants';
 import {generateSecureRandom} from 'react-native-securerandom';
 import forge from 'node-forge';
-import {useState, useEffect} from 'react';
+import {useEffect, useState} from 'react';
 import {Dimensions, Keyboard} from 'react-native';
+import {CredentialSubject} from '../types/VC/ExistingMosipVC/vc';
 
 export const hashData = async (
   data: string,
@@ -141,4 +142,8 @@ export const getScreenHeight = () => {
   const screenHeight = Math.floor(height - keyboardHeight);
 
   return {isSmallScreen, screenHeight};
+};
+
+export const getMosipIdentifier = (credentialSubject: CredentialSubject) => {
+  return credentialSubject.UIN ? credentialSubject.UIN : credentialSubject.VID;
 };

--- a/shared/telemetry/TelemetryConstants.js
+++ b/shared/telemetry/TelemetryConstants.js
@@ -18,6 +18,7 @@ export const TelemetryConstants = {
     dataBackupAndRestoreSetup: 'Data Backup & Restore Setup',
     remove: 'remove VC',
     removeVcMetadata: 'VC metadata removed',
+    vcVerification: 'VC Verification',
   }),
 
   EndEventStatus: Object.freeze({
@@ -43,6 +44,7 @@ export const TelemetryConstants = {
     vcsAreTampered:
       'Tampered cards detected and removed for security reasons. Please download again',
     privateKeyUpdationFailed: 'Failed to store private key in keystore',
+    vcVerificationFailed: 'VC verification Failed with Range Error - ',
   }),
 
   ErrorId: Object.freeze({
@@ -57,6 +59,7 @@ export const TelemetryConstants = {
     appWasReset: 'APP_WAS_RESET',
     vcsAreTampered: 'VC_TAMPERED',
     updatePrivateKey: 'UPDATE_PRIVATE_KEY',
+    vcVerificationFailed: 'VC_VERIFICATION_FAILED',
   }),
 
   Screens: Object.freeze({

--- a/shared/vcjs/verifyCredential.ts
+++ b/shared/vcjs/verifyCredential.ts
@@ -6,6 +6,8 @@ import {AssertionProofPurpose} from '../../lib/jsonld-signatures/purposes/Assert
 import {PublicKeyProofPurpose} from '../../lib/jsonld-signatures/purposes/PublicKeyProofPurpose';
 import {VerifiableCredential} from '../../types/VC/ExistingMosipVC/vc';
 import {Credential} from '../../types/VC/EsignetMosipVC/vc';
+import {getErrorEventData, sendErrorEvent} from '../telemetry/TelemetryUtils';
+import {TelemetryConstants} from '../telemetry/TelemetryConstants';
 
 // FIXME: Ed25519Signature2018 not fully supported yet.
 // Ed25519Signature2018 proof type check is not tested with its real credential
@@ -57,9 +59,8 @@ export async function verifyCredential(
     };
 
     //ToDo - Have to remove once range error is fixed during verification
-    //const result = await vcjs.verifyCredential(vcjsOptions);
-    const result = {verified: true};
-    return handleResponse(result);
+    const result = await vcjs.verifyCredential(vcjsOptions);
+    return handleResponse(result, verifiableCredential);
 
     //ToDo Handle Expiration error message
   } catch (error) {
@@ -70,17 +71,35 @@ export async function verifyCredential(
   }
 }
 
-function handleResponse(result: any) {
+function handleResponse(
+  result: any,
+  verifiableCredential: VerifiableCredential | Credential,
+) {
   var errorMessage = VerificationErrorType.NO_ERROR;
   var isVerifiedFlag = true;
 
   if (!result?.verified) {
-    if (result['results'][0].error.name == 'jsonld.InvalidUrl') {
+    let errorCodeName = result['results'][0].error.name;
+    if (errorCodeName == 'jsonld.InvalidUrl') {
       errorMessage = VerificationErrorType.NETWORK_ERROR;
+      isVerifiedFlag = false;
+    } else if (errorCodeName == VerificationErrorType.RANGE_ERROR) {
+      errorMessage = VerificationErrorType.RANGE_ERROR;
+      const vcIdentifier = verifiableCredential.credentialSubject.UIN
+        ? verifiableCredential.credentialSubject.UIN
+        : verifiableCredential.credentialSubject.VID;
+      sendErrorEvent(
+        getErrorEventData(
+          TelemetryConstants.FlowType.vcVerification,
+          TelemetryConstants.ErrorId.vcVerificationFailed,
+          TelemetryConstants.ErrorMessage.vcVerificationFailed + vcIdentifier,
+        ),
+      );
+      isVerifiedFlag = true;
     } else {
       errorMessage = VerificationErrorType.TECHNICAL_ERROR;
+      isVerifiedFlag = false;
     }
-    isVerifiedFlag = false;
   }
 
   const verificationResult: VerificationResult = {
@@ -93,6 +112,7 @@ function handleResponse(result: any) {
 const VerificationErrorType = {
   NO_ERROR: '',
   TECHNICAL_ERROR: 'technicalError',
+  RANGE_ERROR: 'RangeError',
   NETWORK_ERROR: 'networkError',
   EXPIRATION_ERROR: 'expirationError',
 };


### PR DESCRIPTION
## Description
Mock the Verification of VC only for **RangeError** for MOSIP VC and **Sunbird VC**.

## Issue ticket number and link
[INJIMOB-842](https://mosip.atlassian.net/browse/INJIMOB-842)

## References 
Druid : https://druid.obsrv.mosip.net/unified-console.html#workbench
Kafka : https://kafka.obsrv.mosip.net/ui/clusters/main_kafka/topics/mosip-telemetry/messages?q=VC%20verification&filterQueryType=STRING_CONTAINS&attempt=0&limit=100&seekDirection=FORWARD&seekType=OFFSET&seekTo=0::455549

## Screenshots
Problem with druid in consuming the data from kafka to push in DB.
 
This Screen Shot Give us idea of how the data is pushed to kafka, when verification failed 
![image](https://github.com/mosip/inji/assets/94220135/40fe476b-2426-403a-b240-5d17bf81f3be)



[INJIMOB-842]: https://mosip.atlassian.net/browse/INJIMOB-842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ