### PR TITLE
[INJIMOB-1188] fix binding failure of VCs downloaded via VID

### DIFF
--- a/machines/VerifiableCredential/VCItemMachine/VCItemServices.ts
+++ b/machines/VerifiableCredential/VCItemMachine/VCItemServices.ts
@@ -112,7 +112,7 @@ export const VCItemServices = model => {
         {
           requestTime: String(new Date().toISOString()),
           request: {
-            individualId: getMosipIdentifier(vc.credentialSubject),
+            individualId: VCMetadata.fromVC(context.vcMetadata).id,
             otpChannels: ['EMAIL', 'PHONE'],
           },
         },


### PR DESCRIPTION
Previously, while performing binding (VC activation) requesting OTP was sending individualId from credentialSubject(UIN) and validating OTP was sending individualId from VC metaData(VID) which caused mismatch and eventual binding failure. For resolving this, we are sending same individualId (id from VC metaData).