### PR TITLE
[INJIMOB-1411]: revert tuvali version to 0.4.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@iriscan/biometric-sdk-react-native": "0.2.6",
         "@mosip/pixelpass": "^0.1.5",
         "@mosip/secure-keystore": "^0.1.7",
-        "@mosip/tuvali": "git://github.com/mosip/tuvali.git#develop",
+        "@mosip/tuvali": "^0.4.9",
         "@react-native-clipboard/clipboard": "^1.10.0",
         "@react-native-community/netinfo": "9.3.7",
         "@react-native-google-signin/google-signin": "^10.1.1",
@@ -5689,9 +5689,8 @@
     },
     "node_modules/@mosip/tuvali": {
       "version": "0.4.9",
-      "resolved": "git+ssh://git@github.com/mosip/tuvali.git#1b7fb2575bead357da73f971aceb317e384be543",
-      "integrity": "sha512-220+zbZ3m9LOp2f3upeu500mOr3uxEdnnHvbHayzaZMsBEvK8D7/5UoXSF3OLRJZlZ/f4VKD7GKxMVlZ1thP3Q==",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@mosip/tuvali/-/tuvali-0.4.9.tgz",
+      "integrity": "sha512-WnpnM9EAJKEBdZ71DPSeh2va5LDy01iWFI3Ngtc4KfJ4XHWyQbRQA/1T4QPDgofMTP8wy9wehD7w4m8K8YJdhw==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -33597,9 +33596,9 @@
       "requires": {}
     },
     "@mosip/tuvali": {
-      "version": "git+ssh://git@github.com/mosip/tuvali.git#1b7fb2575bead357da73f971aceb317e384be543",
-      "integrity": "sha512-220+zbZ3m9LOp2f3upeu500mOr3uxEdnnHvbHayzaZMsBEvK8D7/5UoXSF3OLRJZlZ/f4VKD7GKxMVlZ1thP3Q==",
-      "from": "@mosip/tuvali@git://github.com/mosip/tuvali.git#develop",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@mosip/tuvali/-/tuvali-0.4.9.tgz",
+      "integrity": "sha512-WnpnM9EAJKEBdZ71DPSeh2va5LDy01iWFI3Ngtc4KfJ4XHWyQbRQA/1T4QPDgofMTP8wy9wehD7w4m8K8YJdhw==",
       "requires": {}
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@iriscan/biometric-sdk-react-native": "0.2.6",
     "@mosip/pixelpass": "^0.1.5",
     "@mosip/secure-keystore": "^0.1.7",
-    "@mosip/tuvali": "git://github.com/mosip/tuvali.git#develop",
+    "@mosip/tuvali": "^0.4.9",
     "@react-native-clipboard/clipboard": "^1.10.0",
     "@react-native-community/netinfo": "9.3.7",
     "@react-native-google-signin/google-signin": "^10.1.1",


### PR DESCRIPTION
## Description

> Revert tuvali version to 0.4.9

## Issue ticket number and link

>  [INJIMOB-1411](https://mosip.atlassian.net/browse/INJIMOB-1411)

## Screenshots
>
<img width="364" alt="Screenshot 2024-05-31 at 11 28 35" src="https://github.com/mosip/inji/assets/28667452/cf13b4f3-09f4-4149-98ee-a6a7e1529cba">



[INJIMOB-1411]: https://mosip.atlassian.net/browse/INJIMOB-1411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ