### PR TITLE
Tuvali and SecureKeystore version change

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -257,7 +257,7 @@ dependencies {
     implementation("com.facebook.react:react-android")
     implementation 'com.facebook.soloader:soloader:0.10.1+'
     implementation("io.mosip:pixelpass:1.2-SNAPSHOT")
-    implementation("io.mosip:secure-keystore:1.1-SNAPSHOT")
+    implementation("io.mosip:secure-keystore:1.2-SNAPSHOT")
 
     def isGifEnabled = (findProperty('expo.gif.enabled') ?: "") == "true";
     def isWebpEnabled = (findProperty('expo.webp.enabled') ?: "") == "true";

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@expo/metro-config": "~0.10.0",
         "@invertase/react-native-apple-authentication": "^2.3.0",
         "@iriscan/biometric-sdk-react-native": "0.2.6",
-        "@mosip/tuvali": "^0.4.9",
+        "@mosip/tuvali": "0.4.9",
         "@react-native-clipboard/clipboard": "^1.10.0",
         "@react-native-community/netinfo": "9.3.7",
         "@react-native-google-signin/google-signin": "^10.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@expo/metro-config": "~0.10.0",
         "@invertase/react-native-apple-authentication": "^2.3.0",
         "@iriscan/biometric-sdk-react-native": "0.2.6",
-        "@mosip/tuvali": "git://github.com/mosip/tuvali.git#develop",
+        "@mosip/tuvali": "^0.4.9",
         "@react-native-clipboard/clipboard": "^1.10.0",
         "@react-native-community/netinfo": "9.3.7",
         "@react-native-google-signin/google-signin": "^10.1.1",
@@ -136,13 +136,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    ".yalc/react-native-pixelpass": {
-      "version": "1.0.0",
-      "extraneous": true,
-      "peerDependencies": {
-        "react-native": "^0.41.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -5694,9 +5687,8 @@
     },
     "node_modules/@mosip/tuvali": {
       "version": "0.4.9",
-      "resolved": "git+ssh://git@github.com/mosip/tuvali.git#1b7fb2575bead357da73f971aceb317e384be543",
-      "integrity": "sha512-220+zbZ3m9LOp2f3upeu500mOr3uxEdnnHvbHayzaZMsBEvK8D7/5UoXSF3OLRJZlZ/f4VKD7GKxMVlZ1thP3Q==",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@mosip/tuvali/-/tuvali-0.4.9.tgz",
+      "integrity": "sha512-WnpnM9EAJKEBdZ71DPSeh2va5LDy01iWFI3Ngtc4KfJ4XHWyQbRQA/1T4QPDgofMTP8wy9wehD7w4m8K8YJdhw==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -33422,26 +33414,10 @@
         }
       }
     },
-    "@mosip/pixelpass": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@mosip/pixelpass/-/pixelpass-0.1.5.tgz",
-      "integrity": "sha512-4vVB9P54xDi9g+1fwBnD/9h97w/nm0J5RNKkN1L0gCqLdKzzPitehnCreZEhF0pN4uOBKDDwZsRKL5KdZVsFWg==",
-      "requires": {
-        "base45-web": "^1.0.2",
-        "cbor-web": "^9.0.2",
-        "pako": "^2.1.0",
-        "qrcode": "^1.5.3"
-      }
-    },
-    "@mosip/secure-keystore": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@mosip/secure-keystore/-/secure-keystore-0.1.7.tgz",
-      "integrity": "sha512-Yo9pCj1do8mKkwMkhRVbnf0cqOQaD3EJlMgcM8OyEedvB/dA5qQKJ2nDt7SkA+Rjnl1XHmvv6qAmLD1xuOD8kQ=="
-    },
     "@mosip/tuvali": {
-      "version": "git+ssh://git@github.com/mosip/tuvali.git#1b7fb2575bead357da73f971aceb317e384be543",
-      "integrity": "sha512-220+zbZ3m9LOp2f3upeu500mOr3uxEdnnHvbHayzaZMsBEvK8D7/5UoXSF3OLRJZlZ/f4VKD7GKxMVlZ1thP3Q==",
-      "from": "@mosip/tuvali@git://github.com/mosip/tuvali.git#develop",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@mosip/tuvali/-/tuvali-0.4.9.tgz",
+      "integrity": "sha512-WnpnM9EAJKEBdZ71DPSeh2va5LDy01iWFI3Ngtc4KfJ4XHWyQbRQA/1T4QPDgofMTP8wy9wehD7w4m8K8YJdhw==",
       "requires": {}
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@expo/metro-config": "~0.10.0",
     "@invertase/react-native-apple-authentication": "^2.3.0",
     "@iriscan/biometric-sdk-react-native": "0.2.6",
-    "@mosip/tuvali": "^0.4.9",
+    "@mosip/tuvali": "0.4.9",
     "@react-native-clipboard/clipboard": "^1.10.0",
     "@react-native-community/netinfo": "9.3.7",
     "@react-native-google-signin/google-signin": "^10.1.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@expo/metro-config": "~0.10.0",
     "@invertase/react-native-apple-authentication": "^2.3.0",
     "@iriscan/biometric-sdk-react-native": "0.2.6",
-    "@mosip/tuvali": "git://github.com/mosip/tuvali.git#develop",
+    "@mosip/tuvali": "^0.4.9",
     "@react-native-clipboard/clipboard": "^1.10.0",
     "@react-native-community/netinfo": "9.3.7",
     "@react-native-google-signin/google-signin": "^10.1.1",

--- a/shared/cryptoutil/cryptoUtil.ts
+++ b/shared/cryptoutil/cryptoUtil.ts
@@ -15,7 +15,7 @@ export const DUMMY_KEY_FOR_BIOMETRIC_ALIAS =
   '9a6cfc0e-4248-11ee-be56-0242ac120002';
 
 export function generateKeys(): Promise<KeyPair> {
-  return Promise.resolve(RSA.generateKeys(4096));
+  return Promise.resolve(RSA.generateKeys(2048));
 }
 
 /**


### PR DESCRIPTION
## Description

> Tuvali version is reverted back to 0.4.9
> Secure-keystore version is bumped up to 1.2.SNAPSHOT

## Issue ticket number and link

> [INJIMOB-1387](https://mosip.atlassian.net/browse/INJIMOB-1387)
> [INJIMOB-890](https://mosip.atlassian.net/browse/INJIMOB-890)

## Screenshots



[INJIMOB-1387]: https://mosip.atlassian.net/browse/INJIMOB-1387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INJIMOB-890]: https://mosip.atlassian.net/browse/INJIMOB-890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ