### PR TITLE
[Injimob 1192] store wellknown config for received VC to display correct id type

### DIFF
--- a/machines/activityLog.ts
+++ b/machines/activityLog.ts
@@ -4,6 +4,7 @@ import {AppServices} from '../shared/GlobalContext';
 import {ACTIVITY_LOG_STORE_KEY} from '../shared/constants';
 import {StoreEvents} from './store';
 import {ActivityLog} from '../components/ActivityLogEvent';
+import {IssuerWellknownResponse} from './VerifiableCredential/VCMetaMachine/vc';
 
 const model = createModel(
   {
@@ -19,6 +20,13 @@ const model = createModel(
         wellknown,
       }),
       REFRESH: () => ({}),
+      STORE_INCOMING_VC_WELLKNOWN_CONFIG: (
+        issuer: string,
+        wellknown: IssuerWellknownResponse,
+      ) => ({
+        issuer,
+        wellknown,
+      }),
     },
   },
 );
@@ -67,6 +75,9 @@ export const activityLogMachine =
                 },
                 REFRESH: {
                   target: 'refreshing',
+                },
+                STORE_INCOMING_VC_WELLKNOWN_CONFIG: {
+                  actions: 'storeWellknownConfig',
                 },
               },
             },
@@ -141,6 +152,13 @@ export const activityLogMachine =
         setAllWellknownConfigResponse: model.assign({
           wellKnownIssuerMap: (_, event) => {
             return event.response as Record<string, Object>;
+          },
+        }),
+
+        storeWellknownConfig: model.assign({
+          wellKnownIssuerMap: (context, event) => {
+            context.wellKnownIssuerMap[event.issuer] = event.wellknown;
+            return context.wellKnownIssuerMap;
           },
         }),
       },

--- a/machines/activityLog.typegen.ts
+++ b/machines/activityLog.typegen.ts
@@ -20,6 +20,7 @@ export interface Typegen0 {
     setActivities: 'STORE_RESPONSE';
     setAllWellknownConfigResponse: 'STORE_RESPONSE';
     storeActivity: 'LOG_ACTIVITY';
+    storeWellknownConfig: 'STORE_INCOMING_VC_WELLKNOWN_CONFIG';
   };
   eventsCausingDelays: {};
   eventsCausingGuards: {};

--- a/machines/bleShare/scan/scanActions.ts
+++ b/machines/bleShare/scan/scanActions.ts
@@ -192,14 +192,14 @@ export const ScanActions = (model: any, QR_LOGIN_REF_ID: any) => {
     logShared: send(
       (context: any) => {
         const vcMetadata = VCMetadata.fromVC(context.selectedVc?.vcMetadata);
-        const selectedVc = context.QrLoginRef.getSnapshot().context.selectedVc;
+
         return ActivityLogEvents.LOG_ACTIVITY({
           _vcKey: vcMetadata.getVcKey(),
           type: context.shareLogType
             ? context.shareLogType
             : 'VC_SHARED_WITH_VERIFICATION_CONSENT',
           id: vcMetadata.id,
-          idType: getCredentialTypes(selectedVc.verifiableCredential),
+          idType: getCredentialTypes(context.selectedVc.verifiableCredential),
           issuer: vcMetadata.issuer!!,
           timestamp: Date.now(),
           deviceName:
@@ -211,14 +211,13 @@ export const ScanActions = (model: any, QR_LOGIN_REF_ID: any) => {
     ),
 
     logFailedVerification: send(
-      context => {
+      (context: any) => {
         const vcMetadata = VCMetadata.fromVC(context.selectedVc);
-        const selectedVc = context.QrLoginRef.getSnapshot().context.selectedVc;
         return ActivityLogEvents.LOG_ACTIVITY({
           _vcKey: vcMetadata.getVcKey(),
           type: 'PRESENCE_VERIFICATION_FAILED',
           timestamp: Date.now(),
-          idType: getCredentialTypes(selectedVc.verifiableCredential),
+          idType: getCredentialTypes(context.selectedVc.verifiableCredential),
           id: vcMetadata.id,
           issuer: vcMetadata.issuer!!,
           deviceName:

--- a/screens/Request/ReceiveVcScreen.tsx
+++ b/screens/Request/ReceiveVcScreen.tsx
@@ -33,6 +33,10 @@ export const ReceiveVcScreen: React.FC = () => {
     ).then(response => {
       setWellknown(response.wellknown);
       setFields(response.fields);
+      controller.STORE_INCOMING_VC_WELLKNOWN_CONFIG(
+        verifiableCredentialData?.issuer,
+        response.wellknown,
+      );
     });
   }, [verifiableCredentialData?.wellKnown]);
 

--- a/screens/Request/ReceiveVcScreenController.ts
+++ b/screens/Request/ReceiveVcScreenController.ts
@@ -15,10 +15,12 @@ import {
   selectIsVerifyingIdentity,
 } from '../../machines/bleShare/commonSelectors';
 import {RequestEvents} from '../../machines/bleShare/request/requestMachine';
+import {ActivityLogEvents} from '../../machines/activityLog';
 
 export function useReceiveVcScreen() {
   const {appService} = useContext(GlobalContext);
   const requestService = appService.children.get('request')!!;
+  const activityService = appService.children.get('activityLog')!!;
 
   return {
     senderInfo: useSelector(requestService, selectSenderInfo),
@@ -53,5 +55,9 @@ export function useReceiveVcScreen() {
     FACE_VALID: () => requestService.send(RequestEvents.FACE_VALID()),
     FACE_INVALID: () => requestService.send(RequestEvents.FACE_INVALID()),
     RESET: () => requestService.send(RequestEvents.RESET()),
+    STORE_INCOMING_VC_WELLKNOWN_CONFIG: (issuer, wellknown) =>
+      activityService.send(
+        ActivityLogEvents.STORE_INCOMING_VC_WELLKNOWN_CONFIG(issuer, wellknown),
+      ),
   };
 }


### PR DESCRIPTION
## Description

> During the VC share if wallet sends a VC of specific issuer to the verifier and there is no VC downloaded for that issuer on that device then default value will be shown as idType in the History screen so to avoid this and display correct idType we are storing wellknown config for received VC.

## Issue ticket number and link

> Example : [INJIMOB-1192](https://mosip.atlassian.net/browse/INJIMOB-1192)


[INJIMOB-1192]: https://mosip.atlassian.net/browse/INJIMOB-1192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ