### PR TITLE
[INJIMOB-1458] fallback issuers config if wellknown not available

### DIFF
--- a/android/app/src/main/java/io/mosip/residentapp/InjiVciClientModule.java
+++ b/android/app/src/main/java/io/mosip/residentapp/InjiVciClientModule.java
@@ -41,12 +41,20 @@ public class InjiVciClientModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void requestCredential(ReadableMap issuerMetaData, String jwtProofValue, String accessToken, Promise promise) {
         try {
+            CredentialFormat credentialFormat;
+            switch (issuerMetaData.getString("credentialFormat")) {
+                case "ldp_vc":
+                    credentialFormat = CredentialFormat.LDP_VC;
+                    break;
+                default:
+                    credentialFormat = CredentialFormat.LDP_VC;
+            }
             CredentialResponse response = vciClient.requestCredential(new IssuerMetaData(
                             issuerMetaData.getString("credentialAudience"),
                             issuerMetaData.getString("credentialEndpoint"),
                             issuerMetaData.getInt("downloadTimeoutInMilliSeconds"),
                             convertReadableArrayToStringArray(issuerMetaData.getArray("credentialType")),
-                            CredentialFormat.LDP_VC), new JWTProof(jwtProofValue)
+                            credentialFormat), new JWTProof(jwtProofValue)
                     , accessToken);
             promise.resolve(response.toJsonString());
         } catch (Exception exception) {

--- a/components/ActivityLogEvent.ts
+++ b/components/ActivityLogEvent.ts
@@ -24,7 +24,6 @@ export class ActivityLog {
   _vcKey: string;
   timestamp: number;
   deviceName: string;
-  vcLabel: string;
   type: ActivityLogType;
   issuer: string;
 
@@ -35,7 +34,6 @@ export class ActivityLog {
     type = '',
     timestamp = Date.now(),
     deviceName = '',
-    vcLabel = '',
     issuer = '',
   } = {}) {
     this.id = id;
@@ -44,7 +42,6 @@ export class ActivityLog {
     this.type = type;
     this.timestamp = timestamp;
     this.deviceName = deviceName;
-    this.vcLabel = vcLabel;
     this.issuer = issuer;
   }
 

--- a/components/VC/common/VCUtils.tsx
+++ b/components/VC/common/VCUtils.tsx
@@ -15,6 +15,7 @@ import {VCVerification} from '../../VCVerification';
 import {MIMOTO_BASE_URL} from '../../../shared/constants';
 import {VCItemDetailsProps} from '../Views/VCDetailView';
 import {getSelectedCredentialTypeDetails} from '../../../shared/openId4VCI/Utils';
+import {parseJSON} from '../../../shared/Utils';
 
 export const CARD_VIEW_DEFAULT_FIELDS = ['fullName'];
 export const DETAIL_VIEW_DEFAULT_FIELDS = [
@@ -207,7 +208,7 @@ export const getIdType = (
     idType !== undefined
   ) {
     let supportedCredentialsWellknown;
-    wellknown = JSON.parse(wellknown) as Object[];
+    wellknown = parseJSON(wellknown) as unknown as Object[];
     if (!!!wellknown['credentials_supported']) {
       return i18n.t('VcDetails:nationalCard');
     }

--- a/components/openId4VCI/CredentialType.tsx
+++ b/components/openId4VCI/CredentialType.tsx
@@ -9,9 +9,10 @@ import {getDisplayObjectForCurrentLanguage} from '../../shared/openId4VCI/Utils'
 import {CredentialTypes} from '../../machines/VerifiableCredential/VCMetaMachine/vc';
 
 export const CredentialType: React.FC<CredentialTypeProps> = props => {
-  const selectedIssuerDisplayObject = getDisplayObjectForCurrentLanguage(
-    props.item.display,
-  );
+  const selectedIssuerDisplayObject = props.item.display
+    ? getDisplayObjectForCurrentLanguage(props.item.display)
+    : {};
+
   return (
     <Pressable
       accessible={false}
@@ -29,10 +30,11 @@ export const CredentialType: React.FC<CredentialTypeProps> = props => {
             ]
       }>
       <View style={Theme.IssuersScreenStyles.issuerBoxIconContainer}>
-        {SvgImage.IssuerIcon({
-          ...props,
-          displayDetails: selectedIssuerDisplayObject,
-        })}
+        {selectedIssuerDisplayObject?.logo &&
+          SvgImage.IssuerIcon({
+            ...props,
+            displayDetails: selectedIssuerDisplayObject,
+          })}
       </View>
       <View style={Theme.IssuersScreenStyles.issuerBoxContent}>
         <Text

--- a/machines/Issuers/IssuersActions.ts
+++ b/machines/Issuers/IssuersActions.ts
@@ -203,12 +203,11 @@ export const IssuersActions = (model: any) => {
           {
             _vcKey: vcMetadata.getVcKey(),
             type: 'VC_DOWNLOADED',
-            id: vcMetadata.id,
+            id: vcMetadata.displayId,
             idType:
               context.credentialWrapper.verifiableCredential.credentialTypes,
             timestamp: Date.now(),
             deviceName: '',
-            vcLabel: vcMetadata.id,
             issuer: context.selectedIssuerId,
           },
           context.selectedCredentialType,

--- a/machines/QrLogin/QrLoginServices.ts
+++ b/machines/QrLogin/QrLoginServices.ts
@@ -25,7 +25,7 @@ export const QrLoginServices = {
 
   sendAuthenticate: async context => {
     let privateKey;
-    const individualId = context.selectedVc.vcMetadata.id;
+    const individualId = context.selectedVc.vcMetadata.displayId;
     if (!isHardwareKeystoreExists) {
       privateKey = await getPrivateKey(
         context.selectedVc.walletBindingResponse?.walletBindingId,
@@ -72,7 +72,7 @@ export const QrLoginServices = {
 
   sendConsent: async context => {
     let privateKey;
-    const individualId = context.selectedVc.vcMetadata.id;
+    const individualId = context.selectedVc.vcMetadata.displayId;
     if (!isHardwareKeystoreExists) {
       privateKey = await getPrivateKey(
         context.selectedVc.walletBindingResponse?.walletBindingId,

--- a/machines/VerifiableCredential/VCItemMachine/VCItemSelectors.ts
+++ b/machines/VerifiableCredential/VCItemMachine/VCItemSelectors.ts
@@ -133,7 +133,3 @@ export function selectVc(state: State) {
   const {serviceRefs, ...data} = state.context;
   return data;
 }
-
-export function selectId(state: State) {
-  return state.context.vcMetadata.id;
-}

--- a/machines/VerifiableCredential/VCItemMachine/VCItemServices.ts
+++ b/machines/VerifiableCredential/VCItemMachine/VCItemServices.ts
@@ -67,7 +67,7 @@ export const VCItemServices = model => {
           request: {
             authFactorType: 'WLA',
             format: 'jwt',
-            individualId: VCMetadata.fromVC(context.vcMetadata).id,
+            individualId: context.vcMetadata.displayId,
             transactionId: context.bindingTransactionId,
             publicKey: context.publicKey,
             challengeList: [
@@ -107,14 +107,13 @@ export const VCItemServices = model => {
       );
     },
     requestBindingOTP: async context => {
-      const vc = getVerifiableCredential(context.verifiableCredential);
       const response = await request(
         API_URLS.bindingOtp.method,
         API_URLS.bindingOtp.buildURL(),
         {
           requestTime: String(new Date().toISOString()),
           request: {
-            individualId: VCMetadata.fromVC(context.vcMetadata).id,
+            individualId: context.vcMetadata.displayId,
             otpChannels: ['EMAIL', 'PHONE'],
           },
         },
@@ -184,7 +183,7 @@ export const VCItemServices = model => {
             API_URLS.credentialDownload.method,
             API_URLS.credentialDownload.buildURL(),
             {
-              individualId: context.vcMetadata.id,
+              individualId: context.vcMetadata.displayId,
               requestId: context.vcMetadata.requestId,
             },
           );
@@ -194,7 +193,6 @@ export const VCItemServices = model => {
               credential: response.credential,
               verifiableCredential: response.verifiableCredential,
               generatedOn: new Date(),
-              id: context.vcMetadata.id,
               idType: context.vcMetadata.idType,
               requestId: context.vcMetadata.requestId,
               lastVerifiedOn: null,

--- a/machines/bleShare/request/requestMachine.ts
+++ b/machines/bleShare/request/requestMachine.ts
@@ -619,7 +619,7 @@ export const requestMachine =
             return ActivityLogEvents.LOG_ACTIVITY({
               _vcKey: vcMetadata.getVcKey(),
               type: context.receiveLogType,
-              id: vcMetadata.id,
+              id: vcMetadata.displayId,
               idType: getCredentialTypes(
                 context.incomingVc.verifiableCredential,
               ),
@@ -627,7 +627,6 @@ export const requestMachine =
               timestamp: Date.now(),
               deviceName:
                 context.senderInfo.name || context.senderInfo.deviceName,
-              vcLabel: vcMetadata.id,
             });
           },
           {to: context => context.serviceRefs.activityLog},

--- a/machines/bleShare/scan/scanActions.ts
+++ b/machines/bleShare/scan/scanActions.ts
@@ -198,13 +198,12 @@ export const ScanActions = (model: any, QR_LOGIN_REF_ID: any) => {
           type: context.shareLogType
             ? context.shareLogType
             : 'VC_SHARED_WITH_VERIFICATION_CONSENT',
-          id: vcMetadata.id,
+          id: vcMetadata.displayId,
           idType: getCredentialTypes(context.selectedVc.verifiableCredential),
           issuer: vcMetadata.issuer!!,
           timestamp: Date.now(),
           deviceName:
             context.receiverInfo.name || context.receiverInfo.deviceName,
-          vcLabel: vcMetadata.id,
         });
       },
       {to: context => context.serviceRefs.activityLog},
@@ -218,11 +217,10 @@ export const ScanActions = (model: any, QR_LOGIN_REF_ID: any) => {
           type: 'PRESENCE_VERIFICATION_FAILED',
           timestamp: Date.now(),
           idType: getCredentialTypes(context.selectedVc.verifiableCredential),
-          id: vcMetadata.id,
+          id: vcMetadata.displayId,
           issuer: vcMetadata.issuer!!,
           deviceName:
             context.receiverInfo.name || context.receiverInfo.deviceName,
-          vcLabel: vcMetadata.id,
         });
       },
       {to: context => context.serviceRefs.activityLog},
@@ -277,13 +275,12 @@ export const ScanActions = (model: any, QR_LOGIN_REF_ID: any) => {
 
         return ActivityLogEvents.LOG_ACTIVITY({
           _vcKey: '',
-          id: vcMetadata.id,
+          id: vcMetadata.display,
           issuer: vcMetadata.issuer!!,
           idType: getCredentialTypes(selectedVc.verifiableCredential),
           type: 'QRLOGIN_SUCCESFULL',
           timestamp: Date.now(),
           deviceName: '',
-          vcLabel: String(vcMetadata.id),
         });
       },
       {

--- a/screens/Home/MyVcs/HistoryTab.tsx
+++ b/screens/Home/MyVcs/HistoryTab.tsx
@@ -16,7 +16,7 @@ export const HistoryTab: React.FC<HistoryTabProps> = props => {
   return (
     <>
       <Modal
-        headerLabel={props.vcMetadata.id}
+        headerLabel={props.vcMetadata.displayId}
         isVisible={controller.isShowActivities}
         onDismiss={controller.DISMISS}>
         <Column fill>

--- a/screens/Home/MyVcsTab.tsx
+++ b/screens/Home/MyVcsTab.tsx
@@ -183,7 +183,7 @@ export const MyVcsTab: React.FC<HomeScreenTabProps> = props => {
 
   let failedVCsList = [];
   controller.downloadFailedVcs.forEach(vc => {
-    failedVCsList.push(`\n${vc.idType}:${vc.id}`);
+    failedVCsList.push(`\n${vc.idType}:${vc.displayId}`);
   });
 
   const isVerificationFailed = controller.verificationErrorMessage !== '';

--- a/screens/Scan/SendVcScreenController.ts
+++ b/screens/Scan/SendVcScreenController.ts
@@ -80,7 +80,8 @@ export function useSendVcScreen() {
     SELECT_VC_ITEM:
       (index: number) => (vcRef: ActorRefFrom<typeof VCItemMachine>) => {
         setSelectedIndex(index);
-        const {serviceRefs, ...vcData} = vcRef.getSnapshot().context;
+        const {serviceRefs, wellknownResponse, ...vcData} =
+          vcRef.getSnapshot().context;
         scanService.send(
           ScanEvents.SELECT_VC(vcData, VCShareFlowType.SIMPLE_SHARE),
         );

--- a/shared/Utils.ts
+++ b/shared/Utils.ts
@@ -30,3 +30,14 @@ export interface CommunicationDetails {
 export const isMosipVC = (issuer: string) => {
   return issuer === Issuers.Mosip || issuer === Issuers.MosipOtp;
 };
+
+export const parseJSON = (input: any) => {
+  let result = null;
+  try {
+    result = JSON.parse(input);
+  } catch (e) {
+    console.warn('Error occurred while parsing JSON ', e);
+    result = JSON.parse(JSON.stringify(input));
+  }
+  return result;
+};

--- a/shared/VCMetadata.ts
+++ b/shared/VCMetadata.ts
@@ -1,4 +1,9 @@
-import {VC, VcIdType} from '../machines/VerifiableCredential/VCMetaMachine/vc';
+import {
+  Credential,
+  VC,
+  VcIdType,
+  VerifiableCredential,
+} from '../machines/VerifiableCredential/VCMetaMachine/vc';
 import {Protocols} from './openId4VCI/Utils';
 import {getMosipIdentifier} from './commonUtil';
 
@@ -15,6 +20,7 @@ export class VCMetadata {
   protocol?: string = '';
   timestamp?: string = '';
   isVerified: boolean = false;
+  displayId: string = '';
 
   constructor({
     idType = '',
@@ -25,6 +31,7 @@ export class VCMetadata {
     protocol = '',
     timestamp = '',
     isVerified = false,
+    displayId = '',
   } = {}) {
     this.idType = idType;
     this.requestId = requestId;
@@ -34,6 +41,7 @@ export class VCMetadata {
     this.issuer = issuer;
     this.timestamp = timestamp;
     this.isVerified = isVerified;
+    this.displayId = displayId;
   }
 
   //TODO: Remove any typing and use appropriate typing
@@ -47,6 +55,11 @@ export class VCMetadata {
       issuer: vc.issuer,
       timestamp: vc.vcMetadata ? vc.vcMetadata.timestamp : vc.timestamp,
       isVerified: vc.isVerified,
+      displayId: vc.displayId
+        ? vc.displayId
+        : vc.vcMetadata
+        ? vc.vcMetadata.displayId
+        : getDisplayId(vc.verifiableCredential),
     });
   }
 
@@ -94,12 +107,24 @@ export const getVCMetadata = (context: object) => {
     requestId: credentialId ?? null,
     issuer: issuer,
     protocol: protocol,
-    id:
-      context.verifiableCredential?.credential.credentialSubject.policyNumber ||
-      getMosipIdentifier(
-        context.verifiableCredential?.credential.credentialSubject,
-      ),
+    id: `${credentialId} + '_' + ${issuer}`,
     timestamp: context.timestamp ?? '',
     isVerified: context.vcMetadata.isVerified ?? false,
+    displayId: getDisplayId(context.verifiableCredential),
   });
+};
+
+const getDisplayId = (
+  verifiableCredential: VerifiableCredential | Credential,
+) => {
+  if (verifiableCredential?.credential) {
+    return (
+      verifiableCredential.credential?.credentialSubject?.policyNumber ||
+      getMosipIdentifier(verifiableCredential.credential.credentialSubject)
+    );
+  }
+  return (
+    verifiableCredential?.credentialSubject?.policyNumber ||
+    getMosipIdentifier(verifiableCredential.credentialSubject)
+  );
 };

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -27,12 +27,6 @@ export const API_URLS: ApiUrls = {
     buildURL: (issuerId: string): `/${string}` =>
       `/residentmobileapp/issuers/${issuerId}`,
   },
-  // TODO: Remove unused api
-  credentialTypes: {
-    method: 'GET',
-    buildURL: (issuerId: string): `/${string}` =>
-      `/residentmobileapp/issuers/${issuerId}/credentialTypes`,
-  },
   issuerWellknownConfig: {
     method: 'GET',
     buildURL: (requestUrl: `/${string}`): `/${string}` => requestUrl,
@@ -334,7 +328,6 @@ type Api_Params = {
 type ApiUrls = {
   issuersList: Api_Params;
   issuerConfig: Api_Params;
-  credentialTypes: Api_Params;
   issuerWellknownConfig: Api_Params;
   allProperties: Api_Params;
   getIndividualId: Api_Params;

--- a/shared/openId4VCI/Utils.ts
+++ b/shared/openId4VCI/Utils.ts
@@ -30,7 +30,6 @@ export const Protocols = {
 
 export const Issuers = {
   MosipOtp: '',
-  Sunbird: 'Sunbird',
   Mosip: 'Mosip',
 };
 
@@ -47,7 +46,7 @@ export function getVcVerificationDetails(
   return {
     statusType: statusType,
     vcType: idType,
-    vcNumber: vcMetadata.id,
+    vcNumber: vcMetadata.displayId,
   };
 }
 


### PR DESCRIPTION
## Description

> Fallback to config in case of wellknown  being unavailable for VCI flow

In case of
1. well-known availability
Credential_audience, Credential_endpoint, credentialFormat, credentialType, Scope is taken from the wellknown
2. well-known unavailability
We would be the taking the required info from config  (mimoto-issuers-config.json  in mosip-config repo)

Other changes
- Refactoring around identifier (id) of the VC metadata & id displayed (displayId) to user is made. 
More in detail, We have made changes in vcMetadata 
-> to take the id as credential Id of the VC (vc.credential.id - [ref](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-10.html#name-credential-issuer-metadata:~:text=%22id%22%3A%20%22http%3A//example.edu/credentials/3732%22%2C))
-> Introduced displayId attribute to hold the UIN / VID / Policy number

TODO:
OTP flow check

## Issue ticket number and link

> [INJIMOB-1458](https://mosip.atlassian.net/browse/INJIMOB-1458&#41)

## Screenshots

> [Attached in card](https://mosip.atlassian.net/browse/INJIMOB-1458?focusedCommentId=84536) 


[INJIMOB-1458]: https://mosip.atlassian.net/browse/INJIMOB-1458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ