### PR TITLE
[INJIMOB-1423]- Data Backedup size upto 3 decimal points

### DIFF
--- a/shared/commonUtil.ts
+++ b/shared/commonUtil.ts
@@ -121,7 +121,7 @@ export const bytesToMB = (bytes: number): string => {
   }
 
   const megabytes = bytes / BYTES_IN_MEGABYTE;
-  return Number(megabytes).toFixed(2);
+  return Number(megabytes).toFixed(3);
 };
 
 export const getAccountType = () => (isAndroid() ? GMAIL : APPLE);


### PR DESCRIPTION
## Description

> Since the size of the sunbird Vc is small and we are limiting the size to 2 decimal points the Data backed up was showing as 0.00 MB

## Issue ticket number and link

(https://mosip.atlassian.net/browse/INJIMOB-1423))

## Screenshots

<img width="516" alt="Screenshot 2024-06-13 at 10 10 33 AM" src="https://github.com/mosip/inji/assets/115976560/c8065192-2acd-414b-b2a6-0c6924e5e1e8">

