### PR TITLE
[INJIMOB-1503]: fix tour guide buttons misalignment in IOS

### DIFF
--- a/components/CopilotTooltip.tsx
+++ b/components/CopilotTooltip.tsx
@@ -33,7 +33,10 @@ export const CopilotTooltip = () => {
       <Text testID={controller.descriptionTestID}>
         {controller.currentStepDescription}
       </Text>
-      <Row align="space-between" crossAlign="center" margin="25 0 0 0">
+      <Row
+        align="space-between"
+        crossAlign="center"
+        style={Theme.Styles.copilotButtonsContainer}>
         <Text testID={`${controller.CURRENT_STEP}stepCount`} weight="bold">
           {controller.stepCount}
         </Text>

--- a/components/ui/themes/DefaultTheme.ts
+++ b/components/ui/themes/DefaultTheme.ts
@@ -723,6 +723,10 @@ export const DefaultTheme = {
       height: 40,
       marginLeft: 10,
     },
+    copilotButtonsContainer: {
+      marginTop: 25,
+      marginBottom: isIOS() ? 10 : 0,
+    },
   }),
   BannerStyles: StyleSheet.create({
     container: {

--- a/components/ui/themes/PurpleTheme.ts
+++ b/components/ui/themes/PurpleTheme.ts
@@ -726,6 +726,10 @@ export const PurpleTheme = {
       height: 40,
       marginLeft: 10,
     },
+    copilotButtonsContainer: {
+      marginTop: 25,
+      marginBottom: isIOS() ? 10 : 0,
+    },
   }),
   BannerStyles: StyleSheet.create({
     container: {


### PR DESCRIPTION
## Description

> IOS - The buttons in the INJI tour guide are not properly aligned

## Issue ticket number and link

>[INJIMOB-1503](https://mosip.atlassian.net/browse/INJIMOB-1503)

## Screenshots

> ![image](https://github.com/mosip/inji/assets/97477121/683d7a9e-2d19-406b-acc8-245c2c35a1ec)
> ![image (5)](https://github.com/mosip/inji/assets/97477121/b21d4d3a-4a05-48a0-b646-6b6651344fc4)
>![image (4)](https://github.com/mosip/inji/assets/97477121/602149e1-e45a-4568-a7bd-5486da6a0b1f)
>![image (3)](https://github.com/mosip/inji/assets/97477121/a8e1be88-aee3-49de-a40a-4ca6f767e585)
>![image (2)](https://github.com/mosip/inji/assets/97477121/d9634cfe-0d8d-48a2-b189-425314de42de)



[INJIMOB-1503]: https://mosip.atlassian.net/browse/INJIMOB-1503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ