### PR TITLE
[INJIMOB-1552] update vci-client library version in android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -286,7 +286,7 @@ dependencies {
     }
     compileOnly project(':react-native-android-location-services-dialog-box')
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
-    implementation "io.mosip:inji-vci-client:1.2-SNAPSHOT"
+    implementation "io.mosip:inji-vci-client:0.1.0-SNAPSHOT"
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}")
     debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
         exclude group: 'com.facebook.flipper'


### PR DESCRIPTION
## Description

> Update vci-client library version to 0.1.0-SNAPSHOT version to get latest library's changes including fix - attribute name mismatch on serialization process

## Issue ticket number and link

>  [INJIMOB-1152](https://mosip.atlassian.net/browse/INJIMOB-1152&#41)

## Screenshots

Response in INJI mobile's screenshot
>
<img width="525" alt="image" src="https://github.com/mosip/inji/assets/81218987/095fbdad-4a5c-4036-a47c-8cd116f18eb1">



[INJIMOB-1152]: https://mosip.atlassian.net/browse/INJIMOB-1152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ