### PR TITLE
INJIMOB-3385: Fix – Handle Arabic characters in credentialSubject during VP sharing

### DIFF
--- a/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
+++ b/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
@@ -1,6 +1,5 @@
 package io.mosip.residentapp;
 
-import static io.mosip.openID4VP.authorizationResponse.AuthorizationResponseUtilsKt.toJsonString;
 import static io.mosip.openID4VP.constants.FormatType.LDP_VC;
 import static io.mosip.openID4VP.constants.FormatType.MSO_MDOC;
 


### PR DESCRIPTION
INJIMOB-3385: Fix – Handle Arabic characters in credentialSubject during VP sharing

## Description

- > Updated InjiOpenID4VPModule.java to ensure proper parsing of credentials containing Arabic text.
-  >Verified the fix by building and testing the APK using the latest develop branch code.
- > Arabic credentials now parse correctly, and VP sharing completes successfully.

## Issue ticket number and link

>[ INJIMOB-3385](https://mosip.atlassian.net/jira/software/c/projects/INJIMOB/boards/91?selectedIssue=INJIMOB-3385)

## Screenshots

> Add the Screenshots of the feature.
