### PR TITLE
INJIMOB-2574  VCs is not reflecting on the home page

### DIFF
--- a/machines/VerifiableCredential/VCItemMachine/VCItemMachine.ts
+++ b/machines/VerifiableCredential/VCItemMachine/VCItemMachine.ts
@@ -438,8 +438,8 @@ export const VCItemMachine = model.createMachine(
                 on: {
                   STORE_RESPONSE: {
                     actions: [
+                      'removeVcMetaDataFromVcMachineContext',
                       'closeViewVcModal',
-                      'refreshAllVcs',
                       'logRemovedVc',
                     ],
                     target: 'triggerAutoBackup',
@@ -452,11 +452,10 @@ export const VCItemMachine = model.createMachine(
                   onDone: [
                     {
                       cond: 'isSignedIn',
-                      actions: ['sendBackupEvent', 'refreshAllVcs'],
+                      actions: ['sendBackupEvent'],
                       target: '#vc-item-machine.vcUtilitiesState.idle',
                     },
                     {
-                      actions: ['refreshAllVcs'],
                       target: '#vc-item-machine.vcUtilitiesState.idle',
                     },
                   ],
@@ -609,10 +608,13 @@ export const VCItemMachine = model.createMachine(
         states: {
           idle: {},
           verifyingCredential: {
-            entry: [send({
-              type: 'SET_VERIFICATION_STATUS',
-              response: {statusType: BannerStatusType.IN_PROGRESS},
-            }),()=>console.info("auto verification started 🔄")],
+            entry: [
+              send({
+                type: 'SET_VERIFICATION_STATUS',
+                response: {statusType: BannerStatusType.IN_PROGRESS},
+              }),
+              () => console.info('auto verification started 🔄'),
+            ],
 
             invoke: {
               src: 'verifyCredential',


### PR DESCRIPTION
# Description
## Fixed VC deletion bugs: 
- VC count not updating after removal - added immediate context update action,
-  Received VCs incorrectly appearing in My VCs after restore + rapid deletions - removed redundant refresh calls causing race conditions. 

## Issue ticket number and link
[INJIMOB-2574](https://mosip.atlassian.net/browse/INJIMOB-2574)

[INJIMOB-2574]: https://mosip.atlassian.net/browse/INJIMOB-2574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-backup now triggers only the backup action when signed in, reducing unnecessary full refreshes.
  * Credential removal flow no longer triggers a full refresh and properly clears associated credential metadata.

* **Refactor**
  * Standardized verification entry logging for more consistent diagnostic output.
  * Internal verification and storage flows streamlined for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->