### PR TITLE
MOSIP-43658: [UI Automation] Inji Mob - Fix the security hotspot issu…

### DIFF
--- a/injitest/Dockerfile
+++ b/injitest/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get -y update \
 && apt-get install -y unzip jq curl \
 && groupadd -g ${container_user_gid} ${container_user_group} \
 && useradd -u ${container_user_uid} -g ${container_user_group} -s /bin/bash -m ${container_user} \
-&& curl -LO "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+&& curl --proto '=https' --proto-redir '=https' -LO "https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
 && mkdir -p /home/${container_user} \
 && chmod +x kubectl $work_dir/entrypoint.sh \
 && mv kubectl /usr/local/bin/ \


### PR DESCRIPTION
Fix curl command for kubectl download in Dockerfile. This is to fix the security hotspot issue found in sonar cube


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for critical infrastructure component downloads with HTTPS and improved protocol handling.
  * Fixed file ownership and permission issues affecting system functionality.

* **Chores**
  * Minor formatting adjustments for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->