### PR TITLE
MOSIP-43015:Inji Mob - Remove the dependency with the license that is …

### DIFF
--- a/injitest/pom.xml
+++ b/injitest/pom.xml
@@ -113,11 +113,6 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
-            <version>3.15.0.Final</version>
-        </dependency>
-        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20230227</version>
@@ -147,11 +142,6 @@
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>5.3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>

--- a/injitest/src/main/java/inji/api/testscripts/AddIdentity.java
+++ b/injitest/src/main/java/inji/api/testscripts/AddIdentity.java
@@ -14,8 +14,6 @@ import org.testng.*;
 import org.testng.annotations.*;
 import org.testng.internal.BaseTestMethod;
 import org.testng.internal.TestResult;
-
-import javax.ws.rs.core.MediaType;
 import java.lang.reflect.Field;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -103,16 +101,12 @@ public class AddIdentity extends InjiWalletUtil implements ITest {
 
             GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
         } else {
-
             testCaseDTO.setInputTemplate(AdminTestUtil.modifySchemaGenerateHbs(testCaseDTO.isRegenerateHbs()));
             String uin = JsonPrecondtion
                     .getValueFromJson(
-                            RestClient.getRequestWithCookie(ApplnURI + "/v1/idgenerator/uin", MediaType.APPLICATION_JSON,
-                                    MediaType.APPLICATION_JSON, COOKIENAME,
+                            RestClient.getRequestWithCookie(ApplnURI + "/v1/idgenerator/uin", "application/json", "application/json", COOKIENAME,
                                     new KernelAuthentication().getTokenByRole(testCaseDTO.getRole())).asString(),
                             "response.uin");
-
-
             testCaseDTO = InjiWalletUtil.isTestCaseValidForTheExecution(testCaseDTO);
 
             DateFormat dateFormatter = new SimpleDateFormat("yyyyMMddHHmmss");

--- a/injitest/src/main/java/inji/utils/InjiWalletUtil.java
+++ b/injitest/src/main/java/inji/utils/InjiWalletUtil.java
@@ -10,7 +10,7 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.testng.SkipException;
 
-import javax.ws.rs.core.MediaType;
+
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
@@ -108,8 +108,8 @@ public class InjiWalletUtil extends AdminTestUtil {
             if (mimotoActuatorResponseArray == null) {
                 Response response = null;
                 JSONObject responseJson = null;
-                response = RestClient.getRequest(url, MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON);
 
+                response = RestClient.getRequest(url, "application/json", "application/json");
                 responseJson = new JSONObject(response.getBody().asString());
                 mimotoActuatorResponseArray = responseJson.getJSONArray("propertySources");
             }


### PR DESCRIPTION
Removed resteasy-jaxrs and javax.ws.rs-api package dependencies from pom.xml, as This license is not allowed by Mosip EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0

[MOSIP-43015](https://mosip.atlassian.net/browse/MOSIP-43015)


[MOSIP-43015]: https://mosip.atlassian.net/browse/MOSIP-43015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused external dependencies to reduce package overhead and eliminate potential compatibility conflicts.
  * Optimized internal configuration handling by streamlining dependency usage for improved maintainability and system stability.

* **Chores**
  * Cleaned up unused imports throughout the codebase to reduce compilation overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->