### PR TITLE
[INJIMOB-3622]: Fix banner alignment to history page

### DIFF
--- a/screens/History/HistoryScreen.tsx
+++ b/screens/History/HistoryScreen.tsx
@@ -15,17 +15,16 @@ export const HistoryScreen: React.FC<MainRouteProps> = () => {
 
   return (
     <Column fill backgroundColor={Theme.Colors.whiteBackgroundColor}>
+      <BannerNotificationContainer />
       <Column
         scroll
         padding="7 0"
-        style={{flexGrow: 1}}
         refreshControl={
           <RefreshControl
             refreshing={controller.isRefreshing}
             onRefresh={controller.REFRESH}
           />
         }>
-        <BannerNotificationContainer />
         {controller.activities.map(activity => (
           <ActivityLogText
             key={`${activity.timestamp}-${activity._vcKey}`}


### PR DESCRIPTION
## Description

>Fix banner alignment to history page

## Issue ticket number and link

> Example : [INJIMOB-3622](https://mosip.atlassian.net/browse/INJIMOB-3622)



[INJIMOB-3622]: https://mosip.atlassian.net/browse/INJIMOB-3622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Moved the notification banner to the top of the History screen for clearer visibility.
  * Adjusted horizontal alignment of content and the "no history" message for consistent centering.
  * Improved layout and spacing so the history list expands to make better use of available screen space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->