### PR TITLE
Injimob-3649: add delay before rendering WebView to prevent missing authorize call on Android BrowserStack

### DIFF
--- a/screens/AuthWebViewScreen.tsx
+++ b/screens/AuthWebViewScreen.tsx
@@ -22,6 +22,7 @@ const AuthWebViewScreen: React.FC<any> = ({route, navigation}) => {
   const [showWebView, setShowWebView] = useState(false);
   const [shouldRenderWebView, setShouldRenderWebView] = useState(false);
   const {t} = useTranslation('authWebView');
+  const WEBVIEW_INIT_DELAY_MS = 300;
 
   const hostName = new URL(authorizationURL).hostname; // example.mosip.net
   const parsed = psl.parse(hostName);
@@ -84,7 +85,7 @@ const AuthWebViewScreen: React.FC<any> = ({route, navigation}) => {
 
       timeoutId = setTimeout(() => {
         setShouldRenderWebView(false);
-      }, 300);
+      }, WEBVIEW_INIT_DELAY_MS);
     }
 
     return () => {


### PR DESCRIPTION
## Description

> add delay before rendering WebView to prevent missing authorize call on Android BrowserStack

## Issue ticket number and link

> [INJIMOB-3649](https://mosip.atlassian.net/browse/INJIMOB-3649)



[INJIMOB-3649]: https://mosip.atlassian.net/browse/INJIMOB-3649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication WebView startup on Android to prevent flicker and ensure reliable display.
  * "Continue" flow now briefly mounts a hidden placeholder WebView before showing the full WebView, smoothing transitions and producing a more consistent experience on affected devices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->