### PR TITLE
[INJIMOB-3681] add doc for revocation support

### DIFF
--- a/docs/revocation-support.md
+++ b/docs/revocation-support.md
@@ -2,7 +2,7 @@
 
 This document explains how Inji Wallet determines whether a credential is valid, revoked, or in a pending/unknown state.
 
-Revocation is based on the **Status List 2021** mechanism. The wallet currently supports only `statusPurpose = "revocation"`.
+Revocation is based on the [**Status List 2021**](https://www.w3.org/TR/vc-bitstring-status-list/) mechanism. The wallet currently supports only `statusPurpose = "revocation"`. Additionally, the wallet only supports status check of credentials in the `ldp_vc` format. For other formats status check is bypassed for now.
 
 ---
 
@@ -149,5 +149,5 @@ The wallet UI displays this state as **"Status Pending"**.
 
 ## References
 
-- [W3C Status List 2021](https://w3c.github.io/vc-status-list-2021/)
+- [W3C Status List 2021](https://www.w3.org/TR/vc-bitstring-status-list/)
 - Inji Wallet Documentation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation on credential revocation handling via the W3C Status List 2021 mechanism: end-to-end verification flow, extraction and validation steps, decoding and status bit interpretation, mapping to wallet states (VALID / REVOKED / PENDING), platform-specific verification notes, offline behavior guidance, a step-by-step processing guide, and references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->