### PR TITLE
INJIMOB-3672: Fix Add New Card alignment

### DIFF
--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -4,8 +4,10 @@ import {Column, Row} from './Layout';
 import {Theme} from './styleUtils';
 import testIDProps from '../../shared/commonUtil';
 import {BackButton} from './backButton/BackButton';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 export const Header: React.FC<HeaderProps> = ({goBack, title, testID}) => {
+  const insets = useSafeAreaInsets();
   return (
     <Column safe align="center" testID={testID}>
       <Row elevation={2}>
@@ -14,10 +16,9 @@ export const Header: React.FC<HeaderProps> = ({goBack, title, testID}) => {
             flex: 1,
             flexDirection: 'row',
             alignItems: 'center',
-            marginTop: 18,
-            marginBottom: 22,
-            marginVertical: 16,
-            marginLeft: 10,
+            paddingTop: Math.max(insets.top, 24),
+            paddingBottom: 16,
+            paddingHorizontal: 10,
           }}>
           <BackButton onPress={goBack} />
           <Row fill align={'center'}>

--- a/components/ui/themes/DefaultTheme.ts
+++ b/components/ui/themes/DefaultTheme.ts
@@ -1519,6 +1519,7 @@ export const DefaultTheme = {
   IssuersScreenStyles: StyleSheet.create({
     issuerListOuterContainer: {
       padding: 10,
+      paddingHorizontal: 20,
       flex: 1,
       backgroundColor: Colors.White,
     },

--- a/components/ui/themes/PurpleTheme.ts
+++ b/components/ui/themes/PurpleTheme.ts
@@ -1538,6 +1538,7 @@ export const PurpleTheme = {
   IssuersScreenStyles: StyleSheet.create({
     issuerListOuterContainer: {
       padding: 10,
+      paddingHorizontal: 20,
       flex: 1,
       backgroundColor: Colors.White,
     },


### PR DESCRIPTION
## Description

Fixed "Add New Card" alignment clipping on curved/large Android screens (OnePlus 12R, Infinix Note 50x, Moto Edge 50).

Changes:

Header.tsx: Added useSafeAreaInsets() for dynamic paddingTop (prevents status bar overlap)

DefaultTheme/PurpleTheme: Added paddingHorizontal:20 to issuerListOuterContainer (right edge safe zone)


Issue ticket number and link
[INJIMOB-3672](https://mosip.atlassian.net/browse/INJIMOB-3672)

## Screenshots

<img width="416" height="917" alt="image" src="https://github.com/user-attachments/assets/c3202120-7a86-46b6-a1dc-06e3e6d6f3b5" />



https://github.com/user-attachments/assets/73ba5a87-80fb-4361-9d94-68d8505abe61



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved header positioning to respect device safe-area insets, ensuring consistent top/bottom spacing across devices with notches.
  * Increased horizontal padding in issuer list containers to provide better visual balance and spacing for list items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->