### PR TITLE
fix(INJIMOB-3671): Fix selfie icon gradient on consent screen

### DIFF
--- a/assets/Share_with_selfie.svg
+++ b/assets/Share_with_selfie.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="46.094" height="53.752" viewBox="0 0 46.094 53.752">
   <defs>
     <linearGradient id="linear-gradient" x1="0.5" x2="0.5" y2="1" gradientUnits="objectBoundingBox">
-      <stop offset="0" stop-color="@fill2"/>
+      <stop offset="0" stop-color="@fill"/>
       <stop offset="1" stop-color="@fill2"/>
     </linearGradient>
   </defs>


### PR DESCRIPTION
## Description

The selfie icon was displaying in solid purple instead of gradient on the "Share with Selfie" consent screen.

**Root Cause:** The Share_with_selfie.svg had both gradient stops using `@fill2`, causing both colors to be the same (linearGradientEnd/purple).

**Fix:** Changed first gradient stop from `@fill2` to `@fill` to create proper gradient from linearGradientStart (orange) to linearGradientEnd (purple), matching Figma design.

## Issue ticket number and link

[INJIMOB-3671](https://mosip.atlassian.net/browse/INJIMOB-3671)

## Screenshots

<img width="333" height="748" alt="image" src="https://github.com/user-attachments/assets/da0557a7-81a9-4f77-8907-dab832337a72" />

**Testing Note: To verify the bugfix, the FaceVerificationAlertOverlay (Share with Selfie consent screen) was temporarily displayed on app startup by adding test code to App.tsx. This test code has been removed from the final commit.**

## Video

https://github.com/user-attachments/assets/2a82ef04-d4a8-4e9a-8161-a27c966f96dc

