### PR TITLE
INJIMOB-3569: Fix button misalignment when client ID is too long

### DIFF
--- a/components/TrustModal.tsx
+++ b/components/TrustModal.tsx
@@ -25,7 +25,10 @@ export const TrustModal = ({
             <View style={Theme.TrustIssuerScreenStyle.modalOverlay}>
                 <View style={Theme.TrustIssuerScreenStyle.modalContainer}>
                     {(logo || name) && (
-                        <View style={Theme.TrustIssuerScreenStyle.issuerHeader}>
+                        <ScrollView 
+                            style={{ maxHeight: 120, width: '100%' }}
+                            contentContainerStyle={Theme.TrustIssuerScreenStyle.issuerHeader}
+                            showsVerticalScrollIndicator={true}>
                             {logo && (
                                 <Image
                                     source={{ uri: logo }}
@@ -37,7 +40,7 @@ export const TrustModal = ({
                                     {name}
                                 </Text>
                             )}
-                        </View>
+                        </ScrollView>
                     )}
                     <ScrollView
                         style={{ flex: 1, width: '100%' }}


### PR DESCRIPTION
## Description

Fixed button misalignment in trust consent screen when verifier/issuer has a very long client ID.

## Changes
- Wrapped verifier/issuer header in ScrollView with maxHeight: 120px
- Long client names now scroll within fixed height area instead of pushing buttons down
- Maintains consistent button positioning regardless of name length

## Testing
Tested with extremely long client IDs - buttons remain properly aligned and name is fully readable via scrolling.

## Issue ticket number and link

[INJIMOB-3569](https://mosip.atlassian.net/browse/INJIMOB-3569)

## Screenshots

<img width="346" height="758" alt="image" src="https://github.com/user-attachments/assets/306d8036-91d3-4d5a-9a48-ed6e33207f86" />

**Testing Note: To verify the bugfix, the TrustModal (trust verifier consent screen) was temporarily displayed on app startup with an extremely long client ID and a sample logo by adding test code to App.tsx. This test code has been removed from the final commit.**

## Video

https://github.com/user-attachments/assets/7dc586ea-d8f4-4b96-bdc2-9b7536a3cbf8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced issuer header to be scrollable when content exceeds available space, allowing users to access all issuer information without layout constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->