### PR TITLE
fix(INJIMOB-3653): purple color is defined as orange

### DIFF
--- a/components/ui/themes/DefaultTheme.ts
+++ b/components/ui/themes/DefaultTheme.ts
@@ -51,7 +51,7 @@ const Colors = {
   dorColor: '#CBCBCB',
   plainText: '#FFFFFF',
   walletbindingLabel: '#000000',
-  LightOrange: '#F7EDF3',
+  LightOrange: '#FDF1E6',
   GradientColors: ['#FF5300', '#5B03AD'],
   GradientColorsLight: ['#FF5300' + 14, '#5B03AD' + 14],
   DisabledColors: ['#C7C7C7', '#C7C7C7'],


### PR DESCRIPTION
## Description

Fix Color Mismatch in Default Theme

Summary
Resolved a color definition bug where a purple hex code was incorrectly assigned to an orange-named variable in the Default Theme, causing potential UI inconsistencies.

Changes
File: DefaultTheme.ts
Fix: Updated Colors.LightOrange to use a correct orange-based hex code that is consistent with the purple theme's LightOrange.

Corrected Mapping:

Old: LightOrange: '#F7EDF3' (This hex is Lavender/Purple)
<img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/01bd994e-321d-4b56-af20-93059f1bab60" />

New (Fixed): LightOrange: '#FDF1E6' (Correct Light Orange/Peach)
<img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/d3a8ef5b-8ecb-4951-9395-847dab4d4930" />

## Issue ticket number and link

[INJIMOB-3653](https://mosip.atlassian.net/browse/INJIMOB-3653)

## Video

https://github.com/user-attachments/assets/f6d97483-a9c4-4400-ba77-e3d3af4b895e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined theme color palette for improved visual presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->