### PR TITLE
fix(INJIMOB-3729): Remove OTP timer element from DOM on timeout

### DIFF
--- a/screens/Home/MyVcs/OtpVerificationModal.tsx
+++ b/screens/Home/MyVcs/OtpVerificationModal.tsx
@@ -129,12 +129,14 @@ export const OtpVerificationModal: React.FC<
             autosubmit={true}
           />
           <Column crossAlign="center">
-            <Text
-              testID="otpVerificationTimer"
-              color={Theme.Colors.resendCodeTimer}
-              weight="regular">
-              {timer > 0 ? `${t('resendTheCode')} : ${formatTime(timer)}` : ''}
-            </Text>
+            {timer > 0 && (
+              <Text
+                testID="otpVerificationTimer"
+                color={Theme.Colors.resendCodeTimer}
+                weight="regular">
+                {`${t('resendTheCode')} : ${formatTime(timer)}`}
+              </Text>
+            )}
 
             <TouchableOpacity
               testID="resendCodeView"


### PR DESCRIPTION
## Description

The OTP verification timer element (otpVerificationTimer) was previously hidden or emptied but remained in the View Hierarchy after the timeout expired. This caused automation scripts to fail as they detected the element's presence.

Changes:
- Refactored the OTP timer logic in OtpVerificationModal.tsx.
- Replaced the ternary empty string logic with conditional rendering (&& operator).
- The component now unmounts completely when the timer reaches 0.

Testing:
- Verified locally that the element is removed from the component tree upon timeout.
- Confirmed 'Resend OTP' functionality remains accessible.

## Issue ticket number and link

[INJIMOB-3729](https://mosip.atlassian.net/browse/INJIMOB-3729)

## Video

https://github.com/user-attachments/assets/115f6202-704a-4ba3-a5b2-de197928aad0




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTP verification timer rendering behavior for more efficient display updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->