### PR TITLE
INJIMOB:3665 Fix for Highlights in INJI Tour Guide

### DIFF
--- a/patches/react-native-copilot+3.3.2.patch
+++ b/patches/react-native-copilot+3.3.2.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/react-native-copilot/dist/index.js b/node_modules/react-native-copilot/dist/index.js
-index b9127da..1ee63c2 100644
+index b9127da..60f39cc 100644
 --- a/node_modules/react-native-copilot/dist/index.js
 +++ b/node_modules/react-native-copilot/dist/index.js
-@@ -188,11 +188,12 @@ var init_SvgMask = __esm({
+@@ -188,11 +188,13 @@ var init_SvgMask = __esm({
        position,
        canvasSize
      }) => {
@@ -16,11 +16,12 @@ index b9127da..1ee63c2 100644
 +      const positionY = Math.round(Math.max(0, position.y._value));
 +      const sizeX = Math.round(Math.max(0, size.x._value));
 +      const sizeY = Math.round(Math.max(0, size.y._value));
-+      return `M0,0H${canvasSize.x}V${canvasSize.y}H0V0ZM${positionX + cornerRadius},${positionY}H${positionX + sizeX - cornerRadius}Q${positionX + sizeX},${positionY} ${positionX + sizeX},${positionY + cornerRadius}V${positionY + sizeY - cornerRadius}Q${positionX + sizeX},${positionY + sizeY} ${positionX + sizeX - cornerRadius},${positionY + sizeY}H${positionX + cornerRadius}Q${positionX},${positionY + sizeY} ${positionX},${positionY + sizeY - cornerRadius}V${positionY + cornerRadius}Q${positionX},${positionY} ${positionX + cornerRadius},${positionY}Z`;
++      const effectiveCornerRadius = Math.min(cornerRadius, sizeX / 2, sizeY / 2);
++      return `M0,0H${canvasSize.x}V${canvasSize.y}H0V0ZM${positionX + effectiveCornerRadius},${positionY}H${positionX + sizeX - effectiveCornerRadius}Q${positionX + sizeX},${positionY} ${positionX + sizeX},${positionY + effectiveCornerRadius}V${positionY + sizeY - effectiveCornerRadius}Q${positionX + sizeX},${positionY + sizeY} ${positionX + sizeX - effectiveCornerRadius},${positionY + sizeY}H${positionX + effectiveCornerRadius}Q${positionX},${positionY + sizeY} ${positionX},${positionY + sizeY - effectiveCornerRadius}V${positionY + effectiveCornerRadius}Q${positionX},${positionY} ${positionX + effectiveCornerRadius},${positionY}Z`;
      };
      SvgMask = ({
        size,
-@@ -544,6 +545,16 @@ var CopilotModal = (0, import_react5.forwardRef)(
+@@ -544,6 +546,16 @@ var CopilotModal = (0, import_react5.forwardRef)(
          if (!androidStatusBarVisible && import_react_native6.Platform.OS === "android") {
            rect.y -= (_a = import_react_native6.StatusBar.currentHeight) != null ? _a : 0;
          }


### PR DESCRIPTION
## Description

> The highlights in Inji Tour guide was not consistent across larger display or display having swipe navigation
> Updated the patch file to adpat the highlight across devices

## Issue ticket number and link

>  [INJIMOB-3665](https://mosip.atlassian.net/browse/INJIMOB-3665)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed copilot modal positioning on Android to correctly account for the system status bar and edge-to-edge displays.
  * Improved SVG mask geometry to use non-negative, rounded coordinates and an adjusted corner radius for more accurate overlay rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->