### PR TITLE
[INJIMOB-3758] fix: show fallback idType if not available in history

### DIFF
--- a/components/ActivityLogEvent.ts
+++ b/components/ActivityLogEvent.ts
@@ -3,7 +3,6 @@ import {getCredentialTypeFromWellKnown} from './VC/common/VCUtils';
 import * as DateFnsLocale from 'date-fns/locale';
 import {VCItemContainerFlowType} from '../shared/Utils';
 import {TFunction} from 'react-i18next';
-import i18n from '../i18n';
 
 export type ActivityLogType =
   | '' // replacement for undefined
@@ -41,7 +40,6 @@ export class VCActivityLog implements ActivityLog {
 
   constructor({
     id = '',
-    idType = [],
     _vcKey = '',
     type = '',
     timestamp = Date.now(),
@@ -52,7 +50,6 @@ export class VCActivityLog implements ActivityLog {
     vcStatus = '',
   } = {}) {
     this.id = id;
-    this.idType = idType;
     this._vcKey = _vcKey;
     this.type = type;
     this.timestamp = timestamp;


### PR DESCRIPTION
## Description

Add default idType similar to VC mini view for history screen

<img width="754" height="1658" alt="image" src="https://github.com/user-attachments/assets/3a031075-247f-48f1-8a74-7a97f5bc9cae" />

<img width="754" height="1658" alt="image" src="https://github.com/user-attachments/assets/47b70693-71c6-424d-b227-af06b1b10076" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Activity log now shows a localized "identity card" label when specific credential details are missing instead of leaving the field blank.
  * For known credential types, the activity log continues to display the derived card type and preserves existing status display.
  * Action text generation improved to more reliably choose the appropriate label based on available credential information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->