### PR TITLE
[INJIMOB-3570] fix: verifier logo not shown in verifier trust screen

### DIFF
--- a/components/TrustModalVerifier.tsx
+++ b/components/TrustModalVerifier.tsx
@@ -29,6 +29,7 @@ export const TrustModalVerifier = ({
             <View style={Theme.TrustVerifierScreenStyle.issuerHeader}>
               {logo && (
                 <AdaptiveImage
+                  testID="trustVerifierLogo"
                   uri={logo}
                   style={Theme.TrustVerifierScreenStyle.issuerLogo}
                 />

--- a/components/ui/AdaptiveImage.tsx
+++ b/components/ui/AdaptiveImage.tsx
@@ -1,44 +1,43 @@
-import {Image, StyleProp, ImageStyle} from 'react-native';
-import React, {useEffect} from 'react';
+import {Image, ImageStyle, StyleProp} from 'react-native';
+import React from 'react';
 import {SvgUri} from 'react-native-svg';
+import testIDProps from '../../shared/commonUtil';
 
-interface InjiImageProps {
+interface AdaptiveImageProps {
   uri: string;
   style?: StyleProp<ImageStyle>;
-}
-
-type ImageType = 'svg' | 'image';
-
-interface ImageState {
-  uri: string | null;
-  type: ImageType | null;
+  testID: string;
 }
 
 const getPathname = (uri: string): string => uri.split('?')[0].split('#')[0];
 
 const checkIsSvg = (uri: string): boolean => /\.svg$/i.test(getPathname(uri));
 
-export const AdaptiveImage: React.FC<InjiImageProps> = ({uri, style}) => {
-  const [imageState, setImageState] = React.useState<ImageState>({
-    uri: null,
-    type: null,
-  });
+export const AdaptiveImage: React.FC<AdaptiveImageProps> = ({
+  uri,
+  style,
+  testID,
+}) => {
+  if (!uri) return null;
 
-  useEffect(() => {
-    if (!uri) {
-      setImageState({uri: null, type: null});
-      return;
-    }
-    const type: ImageType = checkIsSvg(uri) ? 'svg' : 'image';
-
-    setImageState({uri, type});
-  }, [uri]);
-
-  if (!imageState.uri) return null;
-
-  if (imageState.type === 'svg') {
-    return <SvgUri uri={imageState.uri} style={style} height={60} width={60}/>;
+  if (checkIsSvg(uri)) {
+    return (
+      <SvgUri
+        uri={uri}
+        style={style}
+        height={60}
+        width={60}
+        {...testIDProps(testID)}
+      />
+    );
   }
 
-  return <Image source={{uri: imageState.uri}} style={style} resizeMode="contain"/>;
+  return (
+    <Image
+      source={{uri: uri}}
+      style={style}
+      resizeMode="contain"
+      {...testIDProps(testID)}
+    />
+  );
 };


### PR DESCRIPTION
## Description

- Fix Verifier logo not shown in Verifier trust screen for formats like svg, extenstion not available explicitly in the hosted uri

## Issue ticket number and link

> [INJIMOB-3570](https://mosip.atlassian.net/browse/INJIMOB-3570&#41)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Issuer logos now render reliably from both SVG and standard image sources, improving visual quality and compatibility across devices.
  * Logo loading automatically adapts to the image type for more consistent sizing and display without changing dialog behavior or controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->