### PR TITLE
INJIMOB-1249: Removed sensitive logging data UIN/VID for verification…

### DIFF
--- a/shared/telemetry/TelemetryConstants.js
+++ b/shared/telemetry/TelemetryConstants.js
@@ -50,7 +50,7 @@ export const TelemetryConstants = {
     vcsAreTampered:
       'Tampered cards detected and removed for security reasons. Please download again',
     privateKeyUpdationFailed: 'Failed to store private key in keystore',
-    vcVerificationFailed: 'VC verification Failed with Range Error - ',
+    vcVerificationFailed: 'VC verification failed',
     wellknownConfigMismatch:
       'Selected credential type is not available in wellknown config supported credentials list',
   }),

--- a/shared/vcjs/verifyCredential.ts
+++ b/shared/vcjs/verifyCredential.ts
@@ -10,7 +10,7 @@ import {
 } from '../../machines/VerifiableCredential/VCMetaMachine/vc';
 import {getErrorEventData, sendErrorEvent} from '../telemetry/TelemetryUtils';
 import {TelemetryConstants} from '../telemetry/TelemetryConstants';
-import {getMosipIdentifier} from '../commonUtil';
+
 import {NativeModules} from 'react-native';
 import {isAndroid, isIOS} from '../constants';
 import {VCFormat} from '../VCFormat';
@@ -167,7 +167,6 @@ function handleResponse(
       errorMessage = VerificationErrorMessage.RANGE_ERROR;
       sendVerificationErrorEvent(
         TelemetryConstants.ErrorMessage.vcVerificationFailed,
-        verifiableCredential,
       );
       isVerifiedFlag = true;
       errorCode = VerificationErrorType.RANGE_ERROR;
@@ -193,8 +192,7 @@ async function handleVcVerifierResponse(
           ? VerificationErrorType.GENERIC_TECHNICAL_ERROR
           : verificationResult.verificationErrorCode;
       sendVerificationErrorEvent(
-        verificationResult.verificationMessage,
-        verifiableCredential,
+        TelemetryConstants.ErrorMessage.vcVerificationFailed,
       );
     }
     const isRevoked = await checkIsStatusRevoked(
@@ -211,7 +209,9 @@ async function handleVcVerifierResponse(
       'Error occurred while verifying the VC using VcVerifier Library:',
       error,
     );
-    sendVerificationErrorEvent(error, verifiableCredential);
+    sendVerificationErrorEvent(
+      TelemetryConstants.ErrorMessage.vcVerificationFailed,
+    );
     return {
       isVerified: false,
       verificationMessage: verificationResult.verificationMessage,
@@ -275,24 +275,12 @@ function createSuccessfulVerificationResult(): VerificationResult {
   };
 }
 
-function sendVerificationErrorEvent(
-  errorMessage: string,
-  verifiableCredential: any,
-) {
-  const stacktrace = __DEV__ ? verifiableCredential : {};
-  //Add only UIN / VID in the credential into telemetry error message and not document_number or other identifiers to avoid sensitivity issues
-  let detailedError = errorMessage;
-  if (verifiableCredential.credentialSubject)
-    detailedError += `-${getMosipIdentifier(
-      verifiableCredential.credentialSubject,
-    )}`;
-
+function sendVerificationErrorEvent(errorMessage: string) {
   sendErrorEvent(
     getErrorEventData(
       TelemetryConstants.FlowType.vcVerification,
       TelemetryConstants.ErrorId.vcVerificationFailed,
-      detailedError,
-      stacktrace,
+      errorMessage,
     ),
   );
 }


### PR DESCRIPTION

##  Sensitive data was being logged during vc verification failure

> Removed getMosipIdentifier and detailed error logic from the code now 
> instead of detailed error with UIN/VID will be having normal verification failure message

## Issue ticket number and link

> Example : [INJIMOB-1249](https://mosip.atlassian.net/browse/INJIMOB-1249)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified error telemetry to send only a concise error message instead of credential-specific details.
  * Standardized the verification-failure message wording to a shorter, consistent text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->