### PR TITLE
fix: sonar job - set node version to v18

### DIFF
--- a/.github/workflows/push-triggers.yml
+++ b/.github/workflows/push-triggers.yml
@@ -66,6 +66,7 @@ jobs:
     uses: mosip/kattu/.github/workflows/npm-sonar-analysis.yml@dsd9685
     with:
       SERVICE_LOCATION: '.'
+      NODE_VERSION: '18.x'
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       ORG_KEY: ${{ secrets.ORG_KEY }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to specify Node.js version 18.x, ensuring consistent build environment across CI/CD pipeline processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->