### PR TITLE
[INJIMOB-3795] fix: sonar job | [INJIMOB-3796] chore: update vc-verifier lib version

### DIFF
--- a/.github/workflows/push-triggers.yml
+++ b/.github/workflows/push-triggers.yml
@@ -66,6 +66,7 @@ jobs:
     uses: mosip/kattu/.github/workflows/npm-sonar-analysis.yml@dsd9685
     with:
       SERVICE_LOCATION: '.'
+      NODE_VERSION: '18.x'
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       ORG_KEY: ${{ secrets.ORG_KEY }}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -10,11 +10,13 @@ apply plugin: 'kotlin-android'
 
 configurations.all {
     resolutionStrategy.force 'androidx.activity:activity-ktx:1.7.1', 'androidx.activity:activity:1.7.0', 'com.fasterxml.jackson.core:jackson-core:2.14.0'
-    all*.exclude module: 'bcprov-jdk15to18'
-    all*.exclude module: 'bcutil-jdk18on'
-    all*.exclude module: 'bcprov-jdk15on'
-    all*.exclude module: 'bcutil-jdk15on'
-    all*.exclude module: 'titanium-json-ld'
+    exclude group: 'org.bouncycastle', module: 'bcpkix-jdk15to18'
+    exclude group: 'org.bouncycastle', module: 'bcpkix-jdk18on'
+    exclude module: 'bcprov-jdk15to18'
+    exclude module: 'bcutil-jdk18on'
+    exclude module: 'bcprov-jdk15on'
+    exclude module: 'bcutil-jdk15on'
+    exclude module: 'titanium-json-ld'
 }
 
 react {
@@ -291,7 +293,7 @@ dependencies {
         exclude group: 'io.inji', module: 'inji-openid4vp-aar'
     }
     implementation("com.google.code.gson:gson:2.10.1")
-    implementation("io.mosip:vcverifier-aar:1.6.0-SNAPSHOT") {
+    implementation("io.inji:vcverifier-aar:1.7.0") {
         exclude group: 'org.bouncycastle', module: 'bcpkix-jdk15on'
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI: Added a Node.js version input so the push-trigger workflow now forwards a Node.js version to downstream analysis.
  * Android: Updated the VC verification library to 1.7.0 and adjusted dependency exclusion rules to preserve compatibility with cryptography modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->