### PR TITLE
INJIMOB-3569: Fix alignment isssue with trust verifier screen

### DIFF
--- a/components/TrustModalVerifier.tsx
+++ b/components/TrustModalVerifier.tsx
@@ -25,26 +25,26 @@ export const TrustModalVerifier = ({
     <Modal transparent={true} visible={isVisible} animationType="fade">
       <View style={Theme.TrustVerifierScreenStyle.modalOverlay}>
         <View style={Theme.TrustVerifierScreenStyle.modalContainer}>
-          {(logo || name) && (
-            <View style={Theme.TrustVerifierScreenStyle.issuerHeader}>
-              {logo && (
-                <AdaptiveImage
-                  testID="trustVerifierLogo"
-                  uri={logo}
-                  style={Theme.TrustVerifierScreenStyle.issuerLogo}
-                />
-              )}
-              {name && (
-                <Text style={Theme.TrustVerifierScreenStyle.issuerName}>
-                  {name}
-                </Text>
-              )}
-            </View>
-          )}
           <ScrollView
             style={{flex: 1, width: '100%'}}
             contentContainerStyle={{alignItems: 'center', paddingBottom: 10}}
             showsVerticalScrollIndicator={true}>
+            {(logo || name) && (
+              <View style={Theme.TrustVerifierScreenStyle.issuerHeader}>
+                {logo && (
+                  <AdaptiveImage
+                    testID="trustVerifierLogo"
+                    uri={logo}
+                    style={Theme.TrustVerifierScreenStyle.issuerLogo}
+                  />
+                )}
+                {name && (
+                  <Text style={Theme.TrustVerifierScreenStyle.issuerName}>
+                    {name}
+                  </Text>
+                )}
+              </View>
+            )}
             <Text style={Theme.TrustVerifierScreenStyle.description}>
               {t(flowType === 'issuer' ? 'description' : 'verifierDescription')}
             </Text>

--- a/components/__snapshots__/TrustModalVerifier.test.tsx.snap
+++ b/components/__snapshots__/TrustModalVerifier.test.tsx.snap
@@ -26,33 +26,12 @@ exports[`TrustModalVerifier should match snapshot with issuer flowType 1`] = `
           "alignItems": "center",
           "backgroundColor": "#fff",
           "borderRadius": 20,
-          "height": 470,
+          "height": 733.7,
           "padding": 20,
           "width": "100%",
         }
       }
     >
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "marginBottom": 16,
-            "padding": 10,
-          }
-        }
-      >
-        <Text
-          style={
-            {
-              "fontSize": 16,
-              "fontWeight": "bold",
-              "marginTop": 8,
-            }
-          }
-        >
-          Test Issuer
-        </Text>
-      </View>
       <RCTScrollView
         contentContainerStyle={
           {
@@ -69,6 +48,28 @@ exports[`TrustModalVerifier should match snapshot with issuer flowType 1`] = `
         }
       >
         <View>
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "marginBottom": 16,
+                "padding": 10,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "fontSize": 16,
+                  "fontWeight": "bold",
+                  "marginTop": 8,
+                  "textAlign": "center",
+                }
+              }
+            >
+              Test Issuer
+            </Text>
+          </View>
           <Text
             style={
               {
@@ -465,33 +466,12 @@ exports[`TrustModalVerifier should match snapshot with verifier flowType 1`] = `
           "alignItems": "center",
           "backgroundColor": "#fff",
           "borderRadius": 20,
-          "height": 470,
+          "height": 733.7,
           "padding": 20,
           "width": "100%",
         }
       }
     >
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "marginBottom": 16,
-            "padding": 10,
-          }
-        }
-      >
-        <Text
-          style={
-            {
-              "fontSize": 16,
-              "fontWeight": "bold",
-              "marginTop": 8,
-            }
-          }
-        >
-          Test Issuer
-        </Text>
-      </View>
       <RCTScrollView
         contentContainerStyle={
           {
@@ -508,6 +488,28 @@ exports[`TrustModalVerifier should match snapshot with verifier flowType 1`] = `
         }
       >
         <View>
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "marginBottom": 16,
+                "padding": 10,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "fontSize": 16,
+                  "fontWeight": "bold",
+                  "marginTop": 8,
+                  "textAlign": "center",
+                }
+              }
+            >
+              Test Issuer
+            </Text>
+          </View>
           <Text
             style={
               {
@@ -904,33 +906,12 @@ exports[`TrustModalVerifier should match snapshot without logo 1`] = `
           "alignItems": "center",
           "backgroundColor": "#fff",
           "borderRadius": 20,
-          "height": 470,
+          "height": 733.7,
           "padding": 20,
           "width": "100%",
         }
       }
     >
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "marginBottom": 16,
-            "padding": 10,
-          }
-        }
-      >
-        <Text
-          style={
-            {
-              "fontSize": 16,
-              "fontWeight": "bold",
-              "marginTop": 8,
-            }
-          }
-        >
-          Test Issuer
-        </Text>
-      </View>
       <RCTScrollView
         contentContainerStyle={
           {
@@ -947,6 +928,28 @@ exports[`TrustModalVerifier should match snapshot without logo 1`] = `
         }
       >
         <View>
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "marginBottom": 16,
+                "padding": 10,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "fontSize": 16,
+                  "fontWeight": "bold",
+                  "marginTop": 8,
+                  "textAlign": "center",
+                }
+              }
+            >
+              Test Issuer
+            </Text>
+          </View>
           <Text
             style={
               {
@@ -1343,21 +1346,12 @@ exports[`TrustModalVerifier should match snapshot without name 1`] = `
           "alignItems": "center",
           "backgroundColor": "#fff",
           "borderRadius": 20,
-          "height": 470,
+          "height": 733.7,
           "padding": 20,
           "width": "100%",
         }
       }
     >
-      <View
-        style={
-          {
-            "alignItems": "center",
-            "marginBottom": 16,
-            "padding": 10,
-          }
-        }
-      />
       <RCTScrollView
         contentContainerStyle={
           {
@@ -1374,6 +1368,15 @@ exports[`TrustModalVerifier should match snapshot without name 1`] = `
         }
       >
         <View>
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "marginBottom": 16,
+                "padding": 10,
+              }
+            }
+          />
           <Text
             style={
               {

--- a/components/ui/themes/DefaultTheme.ts
+++ b/components/ui/themes/DefaultTheme.ts
@@ -2303,7 +2303,7 @@ export const DefaultTheme = {
       backgroundColor: '#fff',
       borderRadius: 20,
       width: '100%',
-      height: 470,
+      height: SCREEN_HEIGHT * 0.55,
       padding: 20,
       alignItems: 'center',
     },
@@ -2321,6 +2321,7 @@ export const DefaultTheme = {
       marginTop: 8,
       fontWeight: 'bold',
       fontSize: 16,
+      textAlign: 'center',
     },
     description: {
       fontSize: 14,

--- a/components/ui/themes/PurpleTheme.ts
+++ b/components/ui/themes/PurpleTheme.ts
@@ -2315,7 +2315,7 @@ export const PurpleTheme = {
       backgroundColor: '#fff',
       borderRadius: 20,
       width: '100%',
-      height: 470,
+      height: SCREEN_HEIGHT * 0.55,
       padding: 20,
       alignItems: 'center',
     },
@@ -2333,6 +2333,7 @@ export const PurpleTheme = {
       marginTop: 8,
       fontWeight: 'bold',
       fontSize: 16,
+      textAlign: 'center',
     },
     description: {
       fontSize: 14,


### PR DESCRIPTION
## Description

> Fixed the alignment issue with the verifier consent screen when the client contains a lengthy name
## Issue ticket number and link

> Example : [INJIMOB-3569](https://mosip.atlassian.net/browse/INJIMOB-3569)

## Screenshots

> 
<img width="1264" height="2780" alt="image" src="https://github.com/user-attachments/assets/4e9a828c-231d-476a-b2ed-8a2eac3437f4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated trust verification modal layout to use responsive height based on screen size, replacing fixed dimensions.
  * Centered issuer name text alignment for improved visual appearance.
  * Adjusted scrollable content area to optimize display across different device sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->