### PR TITLE
INJIMOB-3803: Multi lingual support for field name in Detail View of VC

### DIFF
--- a/i18n.ts
+++ b/i18n.ts
@@ -64,7 +64,9 @@ export function getValueForCurrentLanguage(
   const currentLanguageCode = languageCodeMap[currentLanguage];
   if (Array.isArray(localizedData)) {
     const valueForCurrentLanguage = localizedData.filter(
-      obj => obj.language === currentLanguageCode,
+      obj =>
+        obj.language === currentLanguageCode ||
+        obj.language === currentLanguage,
     );
 
     return valueForCurrentLanguage[0]?.value
@@ -82,9 +84,13 @@ export function getClientNameForCurrentLanguage(
   const currentLanguage = i18next.language;
   const currentLanguageCode = languageCodeMap[currentLanguage];
   const localizedDataObject = localizedData as {[key: string]: string};
-  return localizedDataObject.hasOwnProperty(currentLanguageCode)
-    ? localizedDataObject[currentLanguageCode]
-    : localizedDataObject[defaultLanguage];
+  if (localizedDataObject.hasOwnProperty(currentLanguageCode)) {
+    return localizedDataObject[currentLanguageCode];
+  }
+  if (localizedDataObject.hasOwnProperty(currentLanguage)) {
+    return localizedDataObject[currentLanguage];
+  }
+  return localizedDataObject[defaultLanguage];
 }
 
 // This method gets the value from iso-639-3 package, which contains key value pairs of three letter language codes[key] and two letter langugae code[value]. These values are according to iso standards.

--- a/i18n.ts
+++ b/i18n.ts
@@ -60,13 +60,14 @@ export function getValueForCurrentLanguage(
   localizedData: LocalizedField[] | Object,
   defaultLanguage = '@none',
 ) {
-  const currentLanguage = i18next.language;
-  const currentLanguageCode = languageCodeMap[currentLanguage];
+  const currentTwoLetterLanguageCode = i18next.language;
+  const currentThreeLetterLanguageCode =
+    languageCodeMap[currentTwoLetterLanguageCode];
   if (Array.isArray(localizedData)) {
     const valueForCurrentLanguage = localizedData.filter(
       obj =>
-        obj.language === currentLanguageCode ||
-        obj.language === currentLanguage,
+        obj.language === currentThreeLetterLanguageCode ||
+        obj.language === currentTwoLetterLanguageCode,
     );
 
     return valueForCurrentLanguage[0]?.value
@@ -81,14 +82,15 @@ export function getClientNameForCurrentLanguage(
   localizedData: Object,
   defaultLanguage = '@none',
 ) {
-  const currentLanguage = i18next.language;
-  const currentLanguageCode = languageCodeMap[currentLanguage];
+  const currentTwoLetterLanguageCode = i18next.language;
+  const currentThreeLetterLanguageCode =
+    languageCodeMap[currentTwoLetterLanguageCode];
   const localizedDataObject = localizedData as {[key: string]: string};
-  if (localizedDataObject.hasOwnProperty(currentLanguageCode)) {
-    return localizedDataObject[currentLanguageCode];
+  if (localizedDataObject.hasOwnProperty(currentThreeLetterLanguageCode)) {
+    return localizedDataObject[currentThreeLetterLanguageCode];
   }
-  if (localizedDataObject.hasOwnProperty(currentLanguage)) {
-    return localizedDataObject[currentLanguage];
+  if (localizedDataObject.hasOwnProperty(currentTwoLetterLanguageCode)) {
+    return localizedDataObject[currentTwoLetterLanguageCode];
   }
   return localizedDataObject[defaultLanguage];
 }


### PR DESCRIPTION
## Description

> Multi lingual support for field name in Detail View of VC not working
> Fixed multilingual VC field localization by updating [i18n.ts] to resolve labels/values using both 3-letter (hin) and 2-letter (hi) language codes instead of only 3-letter matching.

## Issue ticket number and link

> Example : [INJIMOB-3803](https://mosip.atlassian.net/browse/INJIMOB-3803)

## Attaching video for reference

> 

https://github.com/user-attachments/assets/202d7cdd-b9f8-499f-bb7f-925cb7c80fd4




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language localization matching to accept both two- and three-letter language codes when selecting localized entries and to prefer the best match first. Enhanced fallback behavior to more reliably pick the appropriate language variant or fall back to the default when no match is found, reducing incorrect or missing localized content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->