### PR TITLE
[INJIMOB-3811] docs: add jwt_vc_json support document

### DIFF
--- a/components/VC/common/VCProcessor.test.ts
+++ b/components/VC/common/VCProcessor.test.ts
@@ -149,6 +149,47 @@ describe('VCProcessor', () => {
       expect(result).toHaveProperty('fullResolvedPayload');
     });
   });
+
+  it('should extract credentialSubject from payload.vc for jwt_vc_json', async () => {
+    (jwtDecode as jest.Mock).mockReturnValue({
+      iss: 'https://example.com/issuer',
+      vc: {
+        credentialSubject: {given_name: 'John', family_name: 'Doe'},
+      },
+    });
+    const vcData = {credential: 'header.payload.signature'} as any;
+    const result = await VCProcessor.processForRendering(
+      vcData,
+      VCFormat.jwt_vc_json,
+    );
+    expect(result).toEqual({
+      fullResolvedPayload: {given_name: 'John', family_name: 'Doe'},
+    });
+  });
+
+  it.each([
+    [
+      'payload.vc.credentialSubject is missing',
+      {
+        iss: 'https://example.com/issuer',
+        vc: {},
+      },
+    ],
+    [
+      'payload.vc is missing entirely',
+      {
+        iss: 'https://example.com/issuer',
+      },
+    ],
+  ])('should throw when %s for jwt_vc_json', async (_desc, mockPayload) => {
+    (jwtDecode as jest.Mock).mockReturnValue(mockPayload);
+    const vcData = {credential: 'header.payload.signature'} as any;
+    await expect(
+      VCProcessor.processForRendering(vcData, VCFormat.jwt_vc_json),
+    ).rejects.toThrow(
+      'Invalid jwt_vc_json: missing payload.vc.credentialSubject',
+    );
+  });
 });
 
 describe('reconstructSdJwtFromCompact', () => {

--- a/components/VC/common/VCProcessor.ts
+++ b/components/VC/common/VCProcessor.ts
@@ -41,8 +41,7 @@ export class VCProcessor {
     if (vcFormat === VCFormat.jwt_vc_json) {
       const rawJwt = vcData.credential.toString();
       const payload: any = jwtDecode(rawJwt);
-      const credentialSubject =
-        payload.vc?.credentialSubject ?? payload.credentialSubject ?? payload;
+      const credentialSubject = payload.vc?.credentialSubject;
       return {
         fullResolvedPayload: credentialSubject,
       };

--- a/components/VC/common/VCProcessor.ts
+++ b/components/VC/common/VCProcessor.ts
@@ -42,6 +42,9 @@ export class VCProcessor {
       const rawJwt = vcData.credential.toString();
       const payload: any = jwtDecode(rawJwt);
       const credentialSubject = payload.vc?.credentialSubject;
+      if (credentialSubject == null) {
+        throw new Error('Invalid jwt_vc_json: missing payload.vc.credentialSubject');
+      }
       return {
         fullResolvedPayload: credentialSubject,
       };

--- a/docs/jwt-vc-json-support.md
+++ b/docs/jwt-vc-json-support.md
@@ -108,8 +108,8 @@ After obtaining the credential from the issuing authority through the _inji-vci-
 
 1. [x] Confirm the credential is not tampered with. (Cryptographic Signature Verification)
 
-- **Android** — delegates to the _vc-verifier_ native library (`vcVerifier.verifyAndGetCredentialStatus`).
-- **iOS** — returns a successful verification result directly, consistent with `mso_mdoc`, `vc+sd-jwt`, and `dc+sd-jwt` on iOS.
+- **Android** — delegates to the _vc-verifier_ native library, which performs cryptographic signature verification of the JWT.
+- **iOS** — ⚠️ **Signature verification is skipped entirely.** On iOS, `jwt_vc_json` credentials (along with `mso_mdoc`, `vc+sd-jwt`, and `dc+sd-jwt`) are accepted unconditionally without any cryptographic verification. A tampered or forged credential will pass this step and be saved to the Wallet. This is a known limitation — the Digital Bazaar library used on iOS does not support the signature schemes required for these formats, and this behaviour is temporary until VcVerifier is implemented for iOS.
 
 ##### 6. Return Verification Result
 
@@ -161,10 +161,11 @@ The Wallet uses the cached issuer metadata to render the credential. Field order
 
 #### Field Ordering
 
-Field ordering for `jwt_vc_json` is resolved from the issuer's well-known configuration:
+Field ordering for `jwt_vc_json` is resolved from `matchingWellknownDetails` — the entry in `credential_configurations_supported` that matches the selected `credentialConfigurationId` — using the following fallback chain:
 
-1. If the well-known config contains an `order` array, those field names are used as-is.
-2. Otherwise, the keys of `credential_definition.credentialSubject` are used as the ordered field list.
+1. **`matchingWellknownDetails.order`** — if the `order` array is present and non-empty, those field names are used as-is.
+2. **`matchingWellknownDetails.credential_definition.credentialSubject`** — if `order` is absent, the keys of `credentialSubject` are used as the ordered field list, provided at least one key is present.
+3. **Default fields** — if neither `order` nor `credential_definition.credentialSubject` yields any fields, the wallet falls back to a pre-configured default field list.
 
 #### Field Label Resolution
 

--- a/docs/jwt-vc-json-support.md
+++ b/docs/jwt-vc-json-support.md
@@ -127,7 +127,7 @@ The raw JWT credential is decoded and the `credentialSubject` is extracted from 
 
 The Wallet fetches the issuer's well-known configuration to determine how the credential should be displayed.
 
-```
+```http request
 GET credentialIssuer/.well-known/openid-credential-issuer
 ```
 

--- a/docs/jwt-vc-json-support.md
+++ b/docs/jwt-vc-json-support.md
@@ -1,0 +1,182 @@
+## Support of credential format jwt_vc_json in Inji Wallet
+
+This document provides a comprehensive overview of the process for downloading and rendering a `jwt_vc_json` credential, adhering to the OpenID4VCI specification.
+
+### Scope
+
+- `jwt_vc_json` credential format download, processing, and rendering in Inji Wallet.
+- The credential is issued as a signed JWT whose payload wraps a W3C Verifiable Credential under the `vc` claim. The `credentialSubject` is extracted from `payload.vc.credentialSubject`.
+- Cryptographic Key Binding - JWK is used for proof of possession in the credential request.
+
+### Actors involved
+
+1. Inji Wallet
+2. Issuing Authority
+3. _inji-vci-client_ (Library for downloading credential)
+4. _vc-verifier_ (Library for verification of the downloaded VC)
+
+### Sequence diagram - Download & view jwt_vc_json credential format VC for Wallet Initiated Flow
+
+```mermaid
+sequenceDiagram
+  participant W as Inji Wallet (Mobile App)
+  participant VCI_Lib as Inji VCI Client (Library)
+  participant Issuer as Issuing Authority
+  participant VCVerifier as VC Verifier (Library)
+
+  W -) VCI_Lib: 1. Request jwt_vc_json credential
+  VCI_Lib ->> Issuer: 2. Credential Request
+  Issuer ->> VCI_Lib: 3. Return jwt_vc_json Credential response (signed JWT)
+  VCI_Lib -) W: 4. Return jwt_vc_json Credential
+  W -) VCVerifier: 5. Verify jwt_vc_json Credential
+  VCVerifier -) W: 6. Return Verification Result
+  W ->> W: 7. Save Verified VC
+  W ->> W: 8. Decode JWT, extract credentialSubject as fullResolvedPayload
+  W ->> Issuer: 9. Get credential issuer metadata for rendering (GET /.well-known/openid-credential-issuer)
+  Issuer ->> W: 10. Return credential issuer metadata
+  W ->> W: 11. Use issuer metadata for rendering VC
+```
+
+#### Steps involved
+
+##### 1. Make credential request
+
+Establish communication with the _inji-vci-client_ to submit a credential request to the issuing authority.
+
+##### 2. Credential Request
+
+The _inji-vci-client_ submits the credential request to the issuing authority.
+
+```json
+{
+  "format": "jwt_vc_json",
+  "credential_definition": {
+    "type": ["VerifiableCredential", "ExampleCredential"]
+  },
+  "proof": {
+    "proof_type": "jwt",
+    "jwt": "eyJhbGciOiJFZERTQSIsInR5cCI6Im9wZW5pZDR2Y2ktcHJvb2Yrand0IiwiandrIjp7Li4ufX0..."
+  }
+}
+```
+
+##### 3. Receive the Credential Response
+
+The _inji-vci-client_ receives the credential response as a signed JWT string.
+
+```json
+{
+  "credential": "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiIsImtpZCI6ImV4YW1wbGVLZXkifQ.eyJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSJdLCJpZCI6Imh0dHBzOi8vY3JlZGVudGlhbC1pc3N1ZXIuZXhhbXBsZS5jb20vY3JlZGVudGlhbHMvMzczMiIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJFeGFtcGxlQ3JlZGVudGlhbCJdLCJpc3N1ZXIiOiJodHRwczovL2NyZWRlbnRpYWwtaXNzdWVyLmV4YW1wbGUuY29tIiwiaXNzdWFuY2VEYXRlIjoiMjAyNS0wMS0wMVQwMDowMDowMFoiLCJjcmVkZW50aWFsU3ViamVjdCI6eyJpZCI6ImRpZDpleGFtcGxlOjEyMyIsImdpdmVuX25hbWUiOiJKb2huIiwiZmFtaWx5X25hbWUiOiJEb2UiLCJlbWFpbCI6ImpvaG5AZXhhbXBsZS5jb20ifSwiZGVncmVlIjp7InR5cGUiOiJCYWNoZWxvckRlZ3JlZSIsIm5hbWUiOiJCYWNoZWxvciBvZiBTY2llbmNlIGFuZCBBcnRzIn19LCJpc3MiOiJodHRwczovL2NyZWRlbnRpYWwtaXNzdWVyLmV4YW1wbGUuY29tIiwibmJmIjoxNzM1Njg5NjAwLCJqdGkiOiJodHRwczovL2NyZWRlbnRpYWwtaXNzdWVyLmV4YW1wbGUuY29tL2NyZWRlbnRpYWxzLzM3MzIiLCJzdWIiOiJkaWQ6ZXhhbXBsZToxMjMifQ.k13xQCnQIKAIuwQIbg37dwlNr8D6_2YUQtDTVQCq-ZsjcXxHagGC_VIZtd7RpR8OvBzTBHVwrBRD-_RzoV2Ofg"
+}
+```
+
+The decoded JWT payload:
+
+```json
+{
+  "vc": {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/examples/v1"
+    ],
+    "id": "https://credential-issuer.example.com/credentials/3732",
+    "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+    "issuer": "https://credential-issuer.example.com",
+    "issuanceDate": "2025-01-01T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:jwk:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1NjpWYkpPU3ZqeFU2TDhDN0dVTzRkc2hJWVYzemJ2RndrWUI0M1lKNUt0dDhFIiwia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsImFsZyI6IkVTMjU2IiwieCI6Ik1kQy1PS3E0QVFKZlZDWDV6cFFvTDhqNFZFZnZQWDk4dFU5aHhjTlhHcm8iLCJ5IjoibnNXbmZiNk5Xc0szOUJILWhBYVNrQ1NlNEJ5bWVOc2NKRV9zYUQzRDNiTSJ9",
+      "degree": {
+        "type": "BachelorDegree",
+        "name": "Bachelor of Science and Arts"
+      }
+    }
+  },
+  "iss": "https://credential-issuer.example.com",
+  "nbf": 1735689600,
+  "jti": "https://credential-issuer.example.com/credentials/3732",
+  "sub": "did:jwk:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1NjpWYkpPU3ZqeFU2TDhDN0dVTzRkc2hJWVYzemJ2RndrWUI0M1lKNUt0dDhFIiwia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsImFsZyI6IkVTMjU2IiwieCI6Ik1kQy1PS3E0QVFKZlZDWDV6cFFvTDhqNFZFZnZQWDk4dFU5aHhjTlhHcm8iLCJ5IjoibnNXbmZiNk5Xc0szOUJILWhBYVNrQ1NlNEJ5bWVOc2NKRV9zYUQzRDNiTSJ9"
+}
+```
+
+##### 4. Return the Credential Response
+
+Once the response is received in _inji-vci-client_, it is returned to the Wallet.
+
+##### 5. Perform VC verification
+
+After obtaining the credential from the issuing authority through the _inji-vci-client_ library, a verification process ensures that the issued Verifiable Credential (VC) remains unaltered. The following validations are performed using the _vc-verifier_ library:
+
+1. [x] Confirm the credential is not tampered with. (Cryptographic Signature Verification)
+
+- **Android** — delegates to the _vc-verifier_ native library (`vcVerifier.verifyAndGetCredentialStatus`).
+- **iOS** — returns a successful verification result directly, consistent with `mso_mdoc`, `vc+sd-jwt`, and `dc+sd-jwt` on iOS.
+
+##### 6. Return Verification Result
+
+The verification result is returned to the Wallet.
+
+##### 7. Save Verified VC
+
+If verification succeeds, the credential is saved to the Wallet's store.
+
+##### 8. Decode JWT, extract credentialSubject as fullResolvedPayload
+
+The raw JWT credential is decoded and the `credentialSubject` is extracted from `payload.vc.credentialSubject`. This is stored as `fullResolvedPayload` on the processed credential and is used for all subsequent field rendering.
+
+##### 9. Get credential issuer metadata for rendering
+
+The Wallet fetches the issuer's well-known configuration to determine how the credential should be displayed.
+
+```
+GET credentialIssuer/.well-known/openid-credential-issuer
+```
+
+##### 10. Return credential issuer metadata
+
+The issuing authority returns the well-known metadata, which includes field labels, ordering, and display properties.
+
+```json
+{
+  "credential_configurations_supported": {
+    "ExampleCredential": {
+      "format": "jwt_vc_json",
+      "order": ["given_name", "family_name", "email"],
+      "credential_definition": {
+        "credentialSubject": {
+          "given_name": {"display": [{"name": "Given Name", "locale": "en"}]},
+          "family_name": {"display": [{"name": "Family Name", "locale": "en"}]},
+          "email": {"display": [{"name": "Email", "locale": "en"}]}
+        }
+      }
+    }
+  }
+}
+```
+
+##### 11. Use issuer metadata for rendering VC
+
+The Wallet uses the cached issuer metadata to render the credential. Field ordering is driven by the `order` array if present, otherwise by the keys of `credential_definition.credentialSubject`. Field labels are resolved from each field's `display` array using the wallet's active locale.
+
+### Processing and Rendering
+
+#### Field Ordering
+
+Field ordering for `jwt_vc_json` is resolved from the issuer's well-known configuration:
+
+1. If the well-known config contains an `order` array, those field names are used as-is.
+2. Otherwise, the keys of `credential_definition.credentialSubject` are used as the ordered field list.
+
+#### Field Label Resolution
+
+- Labels are resolved from the issuer's well-known metadata by traversing `credential_definition.credentialSubject.<field-path>.display`.
+- If no `display` metadata exists for a field, the last segment of the field path is formatted as a human-readable label (e.g., `givenName` → `Given Name`).
+
+#### Face / Photo Field
+
+The wallet inspects the resolved credential claims for a face/photo field by recursively searching for a key matching `face`, `photo`, `picture`, `portrait`, or `image` that holds a string value (typically a base64-encoded image).
+
+### Out of scope
+
+- **Revocation** — Inji Wallet does not support revocation for any credential format. This document does not cover revocation of `jwt_vc_json` credentials.
+- **SVG Rendering** — Inji Wallet does not support SVG rendering for any credential format. This document does not cover SVG rendering of `jwt_vc_json` credentials.
+- **OpenID4VP presentation** — Presentation of `jwt_vc_json` credentials to a Verifier is not covered in this document.

--- a/docs/jwt-vc-json-support.md
+++ b/docs/jwt-vc-json-support.md
@@ -32,9 +32,7 @@ sequenceDiagram
   VCVerifier -) W: 6. Return Verification Result
   W ->> W: 7. Save Verified VC
   W ->> W: 8. Decode JWT, extract credentialSubject as fullResolvedPayload
-  W ->> Issuer: 9. Get credential issuer metadata for rendering (GET /.well-known/openid-credential-issuer)
-  Issuer ->> W: 10. Return credential issuer metadata
-  W ->> W: 11. Use issuer metadata for rendering VC
+  W ->> W: 9. Use issuer metadata for rendering VC
 ```
 
 #### Steps involved
@@ -70,7 +68,32 @@ The _inji-vci-client_ receives the credential response as a signed JWT string.
 }
 ```
 
-The decoded JWT payload:
+##### 4. Return the Credential Response
+
+Once the response is received in _inji-vci-client_, it is returned to the Wallet.
+
+##### 5. Perform VC verification
+
+After obtaining the credential from the issuing authority through the _inji-vci-client_ library, a verification process ensures that the issued Verifiable Credential (VC) remains unaltered. The following validations are performed using the _vc-verifier_ library:
+
+1. [x] Confirm the credential is not tampered with. (Cryptographic Signature Verification)
+
+- **Android** — delegates to the _vc-verifier_ native library, which performs cryptographic signature verification of the JWT.
+- **iOS** — ⚠️ **Signature verification is skipped entirely.** On iOS, `jwt_vc_json` credentials (along with `mso_mdoc`, `vc+sd-jwt`, and `dc+sd-jwt`) are accepted unconditionally without any cryptographic verification. A tampered or forged credential will pass this step and be saved to the Wallet. This is a known limitation — the Digital Bazaar library used on iOS does not support the signature schemes required for these formats, and this behaviour is temporary until VcVerifier is implemented for iOS.
+
+##### 6. Return Verification Result
+
+The verification result is returned to the Wallet.
+
+##### 7. Save Verified VC
+
+If verification succeeds, the credential is saved to the Wallet's store.
+
+##### 8. Decode JWT, extract credentialSubject as fullResolvedPayload
+
+The raw JWT credential is decoded and the `credentialSubject` is extracted from `payload.vc.credentialSubject`. This is stored as `fullResolvedPayload` on the processed credential and is used for all subsequent field rendering.
+
+The decoded payload of the JWT credential looks like the following:
 
 ```json
 {
@@ -98,42 +121,11 @@ The decoded JWT payload:
 }
 ```
 
-##### 4. Return the Credential Response
+##### 9. Use issuer metadata for rendering VC
 
-Once the response is received in _inji-vci-client_, it is returned to the Wallet.
+The Wallet uses the cached issuer metadata to render the credential. Field ordering is driven by the `order` array if present, otherwise by the keys of `credential_definition.credentialSubject`. Field labels are resolved from each field's `display` array using the wallet's active locale.
 
-##### 5. Perform VC verification
-
-After obtaining the credential from the issuing authority through the _inji-vci-client_ library, a verification process ensures that the issued Verifiable Credential (VC) remains unaltered. The following validations are performed using the _vc-verifier_ library:
-
-1. [x] Confirm the credential is not tampered with. (Cryptographic Signature Verification)
-
-- **Android** — delegates to the _vc-verifier_ native library, which performs cryptographic signature verification of the JWT.
-- **iOS** — ⚠️ **Signature verification is skipped entirely.** On iOS, `jwt_vc_json` credentials (along with `mso_mdoc`, `vc+sd-jwt`, and `dc+sd-jwt`) are accepted unconditionally without any cryptographic verification. A tampered or forged credential will pass this step and be saved to the Wallet. This is a known limitation — the Digital Bazaar library used on iOS does not support the signature schemes required for these formats, and this behaviour is temporary until VcVerifier is implemented for iOS.
-
-##### 6. Return Verification Result
-
-The verification result is returned to the Wallet.
-
-##### 7. Save Verified VC
-
-If verification succeeds, the credential is saved to the Wallet's store.
-
-##### 8. Decode JWT, extract credentialSubject as fullResolvedPayload
-
-The raw JWT credential is decoded and the `credentialSubject` is extracted from `payload.vc.credentialSubject`. This is stored as `fullResolvedPayload` on the processed credential and is used for all subsequent field rendering.
-
-##### 9. Get credential issuer metadata for rendering
-
-The Wallet fetches the issuer's well-known configuration to determine how the credential should be displayed.
-
-```http request
-GET credentialIssuer/.well-known/openid-credential-issuer
-```
-
-##### 10. Return credential issuer metadata
-
-The issuing authority returns the well-known metadata, which includes field labels, ordering, and display properties.
+Sample issuing metadata, which includes field labels, ordering, and display properties.
 
 ```json
 {
@@ -152,10 +144,6 @@ The issuing authority returns the well-known metadata, which includes field labe
   }
 }
 ```
-
-##### 11. Use issuer metadata for rendering VC
-
-The Wallet uses the cached issuer metadata to render the credential. Field ordering is driven by the `order` array if present, otherwise by the keys of `credential_definition.credentialSubject`. Field labels are resolved from each field's `display` array using the wallet's active locale.
 
 ### Processing and Rendering
 
@@ -178,6 +166,4 @@ The wallet inspects the resolved credential claims for a face/photo field by rec
 
 ### Out of scope
 
-- **Revocation** — Inji Wallet does not support revocation for any credential format. This document does not cover revocation of `jwt_vc_json` credentials.
-- **SVG Rendering** — Inji Wallet does not support SVG rendering for any credential format. This document does not cover SVG rendering of `jwt_vc_json` credentials.
-- **OpenID4VP presentation** — Presentation of `jwt_vc_json` credentials to a Verifier is not covered in this document.
+- **Revocation** — Revocation is not supported for `jwt_vc_json` credentials.

--- a/ios/Inji.xcodeproj/project.pbxproj
+++ b/ios/Inji.xcodeproj/project.pbxproj
@@ -1163,8 +1163,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mosip/secure-keystore-ios-swift";
 			requirement = {
-				branch = develop;
-				kind = branch;
+				kind = exactVersion;
+				version = 0.3.0;
 			};
 		};
 		C33922392E79A536004A01EC /* XCRemoteSwiftPackageReference "inji-vc-renderer-ios-swift" */ = {
@@ -1179,8 +1179,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/inji/inji-openid4vp-ios-swift.git";
 			requirement = {
-				branch = "release-0.7.x";
-				kind = branch;
+				kind = exactVersion;
+				version = 0.7.0;
 			};
 		};
 		C3F18B1B2E320C9A007DBE73 /* XCRemoteSwiftPackageReference "inji-vci-client-ios-swift" */ = {

--- a/ios/Inji.xcodeproj/project.pbxproj
+++ b/ios/Inji.xcodeproj/project.pbxproj
@@ -1163,8 +1163,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mosip/secure-keystore-ios-swift";
 			requirement = {
-				kind = exactVersion;
-				version = 0.3.0;
+				branch = develop;
+				kind = branch;
 			};
 		};
 		C33922392E79A536004A01EC /* XCRemoteSwiftPackageReference "inji-vc-renderer-ios-swift" */ = {

--- a/ios/Inji.xcodeproj/project.pbxproj
+++ b/ios/Inji.xcodeproj/project.pbxproj
@@ -1163,7 +1163,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/mosip/secure-keystore-ios-swift";
 			requirement = {
-				branch = develop;
+				branch = "release-0.4.x";
 				kind = branch;
 			};
 		};
@@ -1187,7 +1187,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/inji/inji-vci-client-ios-swift";
 			requirement = {
-				branch = develop;
+				branch = "release-0.8.x";
 				kind = branch;
 			};
 		};

--- a/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/inji/inji-openid4vp-ios-swift",
       "state" : {
-        "version" : "0.7.0",
-        "revision" : "38e12ead6805da5cc2e214f065a5451f699e91dc"
+        "revision" : "38e12ead6805da5cc2e214f065a5451f699e91dc",
+        "version" : "0.7.0"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mosip/secure-keystore-ios-swift",
       "state" : {
-        "revision" : "1ea5182ca985302d11010b7a16ea496167969ab3",
-        "version" : "0.3.0"
+        "branch" : "develop",
+        "revision" : "c8e4f8ffbba75761fc95e769e7355e463ed7406c"
       }
     },
     {

--- a/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -76,10 +76,10 @@
     {
       "identity" : "inji-openid4vp-ios-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/inji/inji-openid4vp-ios-swift.git",
+      "location" : "https://github.com/inji/inji-openid4vp-ios-swift",
       "state" : {
-        "branch" : "release-0.7.x",
-        "revision" : "b5d0cd00b726ffef428e7e5d95d75fc094da07f3"
+        "version" : "0.7.0",
+        "revision" : "38e12ead6805da5cc2e214f065a5451f699e91dc"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mosip/secure-keystore-ios-swift",
       "state" : {
-        "branch" : "develop",
-        "revision" : "0b73f3e520bcde43cfd4fb460333a19c581599ca"
+        "revision" : "1ea5182ca985302d11010b7a16ea496167969ab3",
+        "version" : "0.3.0"
       }
     },
     {

--- a/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/inji/inji-vci-client-ios-swift",
       "state" : {
-        "branch" : "develop",
-        "revision" : "46e977b7041d871da8f6d217c3d9ccb4743baec0"
+        "branch" : "release-0.8.x",
+        "revision" : "fba7e072f77a2ebe4feb81b614f349c6d6163918"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mosip/secure-keystore-ios-swift",
       "state" : {
-        "branch" : "develop",
-        "revision" : "c8e4f8ffbba75761fc95e769e7355e463ed7406c"
+        "branch" : "release-0.4.x",
+        "revision" : "9e5dc2075eb96d00e9c2ef8f846c6451725f6e6b"
       }
     },
     {

--- a/shared/openId4VCI/Utils.ts
+++ b/shared/openId4VCI/Utils.ts
@@ -68,20 +68,20 @@ export const updateCredentialInformation = async (
   context: any,
   credential: VerifiableCredential,
 ): Promise<CredentialWrapper> => {
-  let processedCredential;
-  if (
-    context.selectedCredentialType.format === VCFormat.mso_mdoc ||
-    context.selectedCredentialType.format === VCFormat.vc_sd_jwt ||
-    context.selectedCredentialType.format === VCFormat.dc_sd_jwt ||
-    context.selectedCredentialType.format === VCFormat.jwt_vc_json
-  ) {
-    processedCredential = await VCProcessor.processForRendering(
-      credential,
-      context.selectedCredentialType.format,
-    );
-  }
   let verifiableCredential;
   try {
+    let processedCredential;
+    if (
+      context.selectedCredentialType.format === VCFormat.mso_mdoc ||
+      context.selectedCredentialType.format === VCFormat.vc_sd_jwt ||
+      context.selectedCredentialType.format === VCFormat.dc_sd_jwt ||
+      context.selectedCredentialType.format === VCFormat.jwt_vc_json
+    ) {
+      processedCredential = await VCProcessor.processForRendering(
+        credential,
+        context.selectedCredentialType.format,
+      );
+    }
     verifiableCredential = {
       ...credential,
       credentialConfigurationId: context.selectedCredentialType.id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added user-facing docs for jwt_vc_json credentials: download, platform verification behavior, storage, rendering rules, issuer metadata, field ordering, label fallbacks, and face/photo detection.

* **Behavior Changes**
  * Rendering now strictly uses the VC object's credentialSubject; non-standard JWT shapes may no longer display.
  * iOS accepts jwt_vc_json credentials without signature verification.
  * Errors during credential rendering are now caught and logged instead of escaping the update flow.

* **Tests**
  * Added tests to ensure jwt_vc_json with missing credentialSubject is rejected. 

* **Chores**
  * iOS Swift package dependencies pinned to released branches/versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->