### PR TITLE
[INJIMOB-3717] remove base74 encoding from git auth token

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -115,7 +115,7 @@ platform :ios do
     match(
       type: 'appstore',
       app_identifier: "#{generate_app_bundle_id}",
-      git_basic_authorization: Base64.strict_encode64("#{GIT_AUTHORIZATION}"),
+      git_basic_authorization: "#{GIT_AUTHORIZATION}",
       readonly: false,
       keychain_name: keychain_name,
       keychain_password: keychain_password,
@@ -191,7 +191,7 @@ platform :ios do
     match(
       type: 'appstore',
       app_identifier: "#{generate_app_bundle_id}",
-      git_basic_authorization: Base64.strict_encode64("#{GIT_AUTHORIZATION}"),
+      git_basic_authorization: "#{GIT_AUTHORIZATION}",
       readonly: false,
       keychain_name: keychain_name,
       keychain_password: keychain_password,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication credential handling in the iOS build pipeline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->