### PR TITLE
fix(vci): align bridges with updated credential responses

### DIFF
--- a/android/app/src/main/java/io/mosip/residentapp/InjiVciClientModule.java
+++ b/android/app/src/main/java/io/mosip/residentapp/InjiVciClientModule.java
@@ -22,7 +22,6 @@ import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSign
 import io.mosip.residentapp.utils.OpenId4VPUtils;
 import io.mosip.vciclient.VCIClient;
 import io.mosip.vciclient.authorizationCodeFlow.clientMetadata.ClientMetadata;
-import io.mosip.vciclient.credential.response.CredentialResponse;
 import io.mosip.vciclient.token.TokenResponse;
 import io.mosip.vciclient.exception.VCIClientException;
 import io.mosip.openID4VP.exceptions.OpenID4VPExceptions;
@@ -95,7 +94,7 @@ public class InjiVciClientModule extends ReactContextBaseJavaModule {
     public void getIssuerMetadata(String credentialIssuer, Promise promise) {
         new Thread(() -> {
             try {
-                Map<String, Object> issuerMetadata = vciClient.getIssuerMetadata(credentialIssuer);
+                Map<String, Object> issuerMetadata = VCIClientBridge.getIssuerMetadataSync(vciClient, credentialIssuer);
                 reactContext.runOnUiQueueThread(() -> {
                     String json = GSON.toJson(issuerMetadata, Map.class);
                     promise.resolve(json);
@@ -116,14 +115,14 @@ public class InjiVciClientModule extends ReactContextBaseJavaModule {
             try {
                 ClientMetadata clientMetadata = GSON.fromJson(clientMetadataJson, ClientMetadata.class);
 
-                CredentialResponse response = VCIClientBridge.requestCredentialByOfferSync(
+                String response = VCIClientBridge.requestCredentialByOfferSync(
                         vciClient,
                         credentialOffer,
                         clientMetadata,
                         signatureSuite);
 
                 reactContext
-                        .runOnUiQueueThread(() -> promise.resolve(response != null ? response.toJsonString() : null));
+                        .runOnUiQueueThread(() -> promise.resolve(response));
             } catch (Exception e) {
                 reactContext.runOnUiQueueThread(() -> rejectVCIException(promise, e));
             }
@@ -138,7 +137,7 @@ public class InjiVciClientModule extends ReactContextBaseJavaModule {
                 ClientMetadata clientMetadata = GSON.fromJson(
                         clientMetadataJson, ClientMetadata.class);
 
-                CredentialResponse response = VCIClientBridge.requestCredentialFromTrustedIssuerSync(
+                String response = VCIClientBridge.requestCredentialFromTrustedIssuerSync(
                         vciClient,
                         credentialIssuer,
                         credentialConfigurationId,
@@ -146,7 +145,7 @@ public class InjiVciClientModule extends ReactContextBaseJavaModule {
                         signatureSuite);
 
                 reactContext.runOnUiQueueThread(() -> {
-                    promise.resolve(response != null ? response.toJsonString() : null);
+                    promise.resolve(response);
                 });
             } catch (Exception e) {
                 reactContext.runOnUiQueueThread(() -> rejectVCIException(promise, e));

--- a/android/app/src/main/java/io/mosip/residentapp/VCIClientBridge.kt
+++ b/android/app/src/main/java/io/mosip/residentapp/VCIClientBridge.kt
@@ -6,11 +6,14 @@ import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPTokenV
 import io.mosip.vciclient.VCIClient
 import io.mosip.vciclient.authorizationCodeFlow.AuthorizationMethod
 import io.mosip.vciclient.authorizationCodeFlow.clientMetadata.ClientMetadata
+import com.google.gson.JsonObject
 import io.mosip.vciclient.constants.OpenWebPageCallback
-import io.mosip.vciclient.constants.ProofJwtCallback
+import io.mosip.vciclient.constants.ProofsCallback
 import io.mosip.vciclient.constants.SelectCredentialsForPresentationCallback
 import io.mosip.vciclient.constants.SignVerifiablePresentationCallback
 import io.mosip.vciclient.credential.response.CredentialResponse
+import io.mosip.vciclient.exception.DownloadFailedException
+import io.mosip.vciclient.proof.CredentialRequestProofs
 import io.mosip.vciclient.token.TokenRequest
 import io.mosip.vciclient.token.TokenResponse
 import kotlinx.coroutines.runBlocking
@@ -22,22 +25,30 @@ object VCIClientBridge {
 
 
     @JvmStatic
+    fun getIssuerMetadataSync(
+            client: VCIClient,
+            credentialIssuer: String
+    ): Map<String, Any?> = runBlocking {
+        client.getIssuerMetadata(credentialIssuer)
+    }
+
+    @JvmStatic
     fun requestCredentialByOfferSync(
             client: VCIClient,
             offer: String,
             clientMetaData: ClientMetadata,
             signatureSuite: String?
-    ): CredentialResponse = runBlocking {
-      //TODO: change method name to fetchCredentialUsingCredentialOffer
-        client.fetchCredentialUsingCredentialOffer(
+    ): String = runBlocking {
+       val response = client.fetchCredentialsUsingCredentialOffer(
                 credentialOffer = offer,
                 clientMetadata = clientMetaData,
                 getTxCode = getTxCodeCallback(),
                 authorizations = authorizationMethods(signatureSuite),
                 getTokenResponse = getTokenResponseCallback(),
-                getProofJwt = getProofJwtCallback(),
+                getProofs = getProofsCallback(),
                 onCheckIssuerTrust = onCheckIssuerTrustCallback()
         )
+        response.toSingleCredentialResponseJson()
     }
 
 
@@ -49,15 +60,15 @@ object VCIClientBridge {
             credentialConfigurationId: String,
             clientMetaData: ClientMetadata,
             signatureSuite: String?
-    ): CredentialResponse = runBlocking {
-        client.fetchCredentialFromTrustedIssuer(
+    ): String = runBlocking {
+        client.fetchCredentialsFromTrustedIssuer(
                 credentialIssuer = credentialIssuer,
                 credentialConfigurationId = credentialConfigurationId,
                 clientMetadata = clientMetaData,
                 getTokenResponse = getTokenResponseCallback(),
                 authorizations = authorizationMethods(signatureSuite),
-                getProofJwt = getProofJwtCallback(),
-        )
+                getProofs = getProofsCallback(),
+        ).toSingleCredentialResponseJson()
     }
 
     private fun authorizationMethods(signatureSuite: String?): List<AuthorizationMethod> =
@@ -115,7 +126,7 @@ object VCIClientBridge {
     }
 
 
-    private fun getProofJwtCallback(): ProofJwtCallback =
+    private fun getProofsCallback(): ProofsCallback =
             {
                     credentialIssuer: String,
                     cNonce: String?,
@@ -127,7 +138,7 @@ object VCIClientBridge {
                         cNonce,
                         proofSigningAlgorithmsSupported
                 )
-                VCIClientCallbackBridge.awaitProof()
+                CredentialRequestProofs(proofs = listOf(VCIClientCallbackBridge.awaitProof()))
             }
 
     private fun getTokenResponseCallback(): suspend (TokenRequest) -> TokenResponse =
@@ -171,4 +182,17 @@ object VCIClientBridge {
                 )
                 VCIClientCallbackBridge.awaitIssuerTrustResponse()
             }
+
+        private fun CredentialResponse.toSingleCredentialResponseJson(): String {
+
+        val firstItem = credentials?.firstOrNull()
+                ?: throw DownloadFailedException("No credential returned from issuer")
+
+        val json = JsonObject().apply {
+            add("credential", firstItem.credential)
+            credentialIssuer?.let { addProperty("credentialIssuer", it) }
+            credentialConfigurationId?.let { addProperty("credentialConfigurationId", it) }
+        }
+        return json.toString()
+    }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,6 +14,7 @@ buildscript {
         google()
         jcenter()
         mavenCentral()
+        mavenLocal()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:8.4.0")
@@ -28,6 +29,7 @@ buildscript {
 def expoCameraMavenPath = new File(["node", "--print", "require.resolve('expo-camera/package.json')"].execute(null, rootDir).text.trim(), "../android/maven")
 allprojects { repositories {
     maven{url("https://central.sonatype.com/repository/maven-snapshots/")}
+    mavenLocal()
     maven { url(expoCameraMavenPath) }
     mavenCentral()
     maven {url("https://repo.danubetech.com/repository/maven-public/")}

--- a/components/VC/common/VCUtils.tsx
+++ b/components/VC/common/VCUtils.tsx
@@ -18,6 +18,7 @@ import {VCItemDetailsProps} from '../Views/VCDetailView';
 import {
   getDisplayObjectForCurrentLanguage,
   getMatchingCredentialIssuerMetadata,
+  serializeClaimPath,
 } from '../../../shared/openId4VCI/Utils';
 import {VCFormat} from '../../../shared/VCFormat';
 import {displayType} from '../../../machines/Issuers/IssuersMachine';
@@ -97,25 +98,72 @@ export const getFieldValue = (
       );
     default: {
       if (format === VCFormat.ldp_vc) {
-        const fieldValue = verifiableCredential?.credentialSubject[field];
-        if (Array.isArray(fieldValue) && typeof fieldValue[0] !== 'object') {
-          return fieldValue.join(', ');
+        const fieldParts = field.split('.');
+        let value: any = verifiableCredential?.credentialSubject;
+
+        for (let i = 0; i < fieldParts.length; i++) {
+          const part = fieldParts[i];
+          if (value == null) break;
+          value = value[part];
+
+          if (Array.isArray(value) && i < fieldParts.length - 1) {
+            if (/^\d+$/.test(fieldParts[i + 1])) continue;
+            const remainingPath = fieldParts.slice(i + 1);
+            value = value.map(item => {
+              let inner = item;
+              for (const p of remainingPath) inner = inner?.[p];
+              return inner;
+            });
+            break;
+          }
         }
-        return getLocalizedField(fieldValue);
+
+        if (Array.isArray(value) && typeof value[0] !== 'object') {
+          return value.join(', ');
+        }
+        return getLocalizedField(value);
       } else if (format === VCFormat.mso_mdoc) {
         const splitField = field.split('~');
         if (splitField.length > 1) {
-          const [namespace, fieldName] = splitField;
-          const fieldValue = iterateMsoMdocFor(
+          const [namespace, fieldName, ...rest] = splitField;
+          let value: any = iterateMsoMdocFor(
             verifiableCredential,
             namespace,
             'elementValue',
             fieldName,
           );
-          if (fieldValue && typeof fieldValue === 'object') {
+
+          for (let i = 0; i < rest.length; i++) {
+            if (value == null) break;
+            const part = rest[i];
+            if (Array.isArray(value)) {
+              if (/^\d+$/.test(part)) {
+                value = value[Number(part)];
+              } else {
+                const remainingPath = rest.slice(i);
+                value = value.map(item => {
+                  let inner = item;
+                  for (const p of remainingPath) inner = inner?.[p];
+                  return inner;
+                });
+                break;
+              }
+            } else if (typeof value === 'object') {
+              value = value[part];
+            } else {
+              value = undefined;
+              break;
+            }
+          }
+
+          if (Array.isArray(value) && typeof value[0] !== 'object') {
+            return value.join(', ');
+          }
+          if (value && typeof value === 'object') {
+            const leafKey = rest.length ? rest[rest.length - 1] : fieldName;
             const elements = renderFieldRecursively(
-              fieldName,
-              fieldValue,
+              leafKey,
+              value,
               display.getTextColor(Theme.Colors.DetailsLabel),
               display.getTextColor(Theme.Colors.Details),
               namespace,
@@ -126,7 +174,7 @@ export const getFieldValue = (
             // exclude the first element which is the namespace title
             return <Column>{elements.slice(1)}</Column>;
           }
-          return fieldValue;
+          return value;
         }
       } else if (
         format === VCFormat.vc_sd_jwt ||
@@ -144,6 +192,11 @@ export const getFieldValue = (
 
           // If we hit an array and we still have more path to go...
           if (Array.isArray(value) && i < fieldParts.length - 1) {
+            // Explicit non-negative integer index (Appendix C.1): bracket
+            // access on the next loop iteration handles it correctly.
+            if (/^\d+$/.test(fieldParts[i + 1])) continue;
+            // Otherwise iterate the remaining path across all elements
+            // (implicit null-wildcard behavior).
             const remainingPath = fieldParts.slice(i + 1);
             value = value.map(item => {
               let inner = item;
@@ -195,6 +248,24 @@ export const getFieldName = (
   format: string,
 ): string => {
   if (wellknown) {
+    // OpenID4VCI Final 1.0: claims is a flat array of {path, display}
+    // (Appendix B.2). Match by serialized path rather than tree-walk.
+    if (Array.isArray(wellknown.claims)) {
+      const match = wellknown.claims.find(
+        (c: any) => serializeClaimPath(c?.path, format) === field,
+      );
+      if (match?.display && Array.isArray(match.display)) {
+        const newFieldObj = match.display.map((obj: any) => ({
+          language: obj.locale,
+          value: obj.name,
+        }));
+        return getLocalizedField(newFieldObj);
+      }
+      const leaf = field.includes('~')
+        ? field.split('~').pop()!
+        : field.split('.').pop()!;
+      return formatKeyLabel(leaf);
+    }
     if (format === VCFormat.ldp_vc) {
       const credentialDefinition = wellknown.credential_definition;
       if (!credentialDefinition) {
@@ -532,6 +603,10 @@ export const fieldItemIterator = (
   const renderedFields = new Set<string>();
 
   const renderedMainFields = fields.map(field => {
+    if (shouldExcludeField(field)) {
+      renderedFields.add(field);
+      return null;
+    }
     const fieldName = getFieldName(
       field,
       wellknown,

--- a/ios/Inji.xcodeproj/project.pbxproj
+++ b/ios/Inji.xcodeproj/project.pbxproj
@@ -1050,7 +1050,10 @@
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -1111,7 +1114,10 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -1187,7 +1193,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/inji/inji-vci-client-ios-swift";
 			requirement = {
-				branch = "release-0.8.x";
+				branch = develop;
 				kind = branch;
 			};
 		};

--- a/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/inji/inji-vci-client-ios-swift",
       "state" : {
-        "branch" : "release-0.8.x",
-        "revision" : "fba7e072f77a2ebe4feb81b614f349c6d6163918"
+        "branch" : "develop",
+        "revision" : "5a76ed0f74a366c222516e07427e4701aac7e517"
       }
     },
     {

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -47,6 +47,15 @@ target 'Inji' do
 
   post_install do |installer|
     installer.pods_project.targets.each do |target|
+      if ['RNArgon2'].include?(target.name)
+        target.build_configurations.each do |config|
+          config.build_settings['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'
+          config.build_settings['DEFINES_MODULE'] = 'YES'
+          config.build_settings['CLANG_ENABLE_MODULES'] = 'YES'
+        end
+      end
+    end
+    installer.pods_project.targets.each do |target|
       if target.name == 'RNZipArchive'
         target.source_build_phase.files.each do |file|
           if file.settings && file.settings['COMPILER_FLAGS']

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -159,6 +159,18 @@ PODS:
   - hermes-engine/Pre-built (0.74.5)
   - ImageColors (2.4.0):
     - ExpoModulesCore
+  - libwebp (1.5.0):
+    - libwebp/demux (= 1.5.0)
+    - libwebp/mux (= 1.5.0)
+    - libwebp/sharpyuv (= 1.5.0)
+    - libwebp/webp (= 1.5.0)
+  - libwebp/demux (1.5.0):
+    - libwebp/webp
+  - libwebp/mux (1.5.0):
+    - libwebp/demux
+  - libwebp/sharpyuv (1.5.0)
+  - libwebp/webp (1.5.0):
+    - libwebp/sharpyuv
   - MLImage (1.0.0-beta2)
   - MLKitCommon (5.0.0):
     - GoogleDataTransport (~> 9.0)
@@ -1449,6 +1461,10 @@ PODS:
     - React-Core
   - RNDeviceInfo (10.14.0):
     - React-Core
+  - RNFastImage (8.6.3):
+    - React-Core
+    - SDWebImage (~> 5.11.1)
+    - SDWebImageWebPCoder (~> 0.8.4)
   - RNFS (2.20.0):
     - React-Core
   - RNGestureHandler (2.16.2):
@@ -1514,6 +1530,12 @@ PODS:
   - RNZipArchive/Core (6.1.0):
     - React-Core
     - SSZipArchive (~> 2.2)
+  - SDWebImage (5.11.1):
+    - SDWebImage/Core (= 5.11.1)
+  - SDWebImage/Core (5.11.1)
+  - SDWebImageWebPCoder (0.8.5):
+    - libwebp (~> 1.0)
+    - SDWebImage/Core (~> 5.10)
   - SocketRocket (0.7.0)
   - "sqlite3 (3.45.3+1)":
     - "sqlite3/common (= 3.45.3+1)"
@@ -1634,6 +1656,7 @@ DEPENDENCIES:
   - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
   - "RNCPicker (from `../node_modules/@react-native-picker/picker`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
+  - RNFastImage (from `../node_modules/react-native-fast-image`)
   - RNFS (from `../node_modules/react-native-fs`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - "RNGoogleSignin (from `../node_modules/@react-native-google-signin/google-signin`)"
@@ -1659,6 +1682,7 @@ SPEC REPOS:
     - GoogleUtilitiesComponents
     - GTMAppAuth
     - GTMSessionFetcher
+    - libwebp
     - MLImage
     - MLKitCommon
     - MLKitFaceDetection
@@ -1669,6 +1693,8 @@ SPEC REPOS:
     - PromisesObjC
     - Protobuf
     - ReachabilitySwift
+    - SDWebImage
+    - SDWebImageWebPCoder
     - SocketRocket
     - sqlite3
     - SSZipArchive
@@ -1874,6 +1900,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-picker/picker"
   RNDeviceInfo:
     :path: "../node_modules/react-native-device-info"
+  RNFastImage:
+    :path: "../node_modules/react-native-fast-image"
   RNFS:
     :path: "../node_modules/react-native-fs"
   RNGestureHandler:
@@ -1939,6 +1967,7 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
   hermes-engine: 8c1577f3fdb849cbe7729c2e7b5abc4b845e88f8
   ImageColors: 88be684570585c07ae2750bff34eb7b78bfc53b4
+  libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   MLImage: a454f9f8ecfd537783a12f9488f5be1a68820829
   MLKitCommon: 3bc17c6f7d25ce3660f030350b46ae7ec9ebca6e
   MLKitFaceDetection: 617cb847441868a8bfd4b48d751c9b33c1104948
@@ -2017,6 +2046,7 @@ SPEC CHECKSUMS:
   RNCClipboard: 3f0451a8100393908bea5c5c5b16f96d45f30bfc
   RNCPicker: 3e2c37a8328f368ce14da050cdc8231deb5fc9f9
   RNDeviceInfo: 59344c19152c4b2b32283005f9737c5c64b42fba
+  RNFastImage: 5c9c9fed9c076e521b3f509fe79e790418a544e8
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNGestureHandler: 2282cfbcf86c360d29f44ace393203afd5c6cff7
   RNGoogleSignin: aac5c1ec73422109dec1da770247a1e410dcc620
@@ -2027,6 +2057,8 @@ SPEC CHECKSUMS:
   RNShare: 0fad69ae2d71de9d1f7b9a43acf876886a6cb99c
   RNSVG: 43b64ed39c14ce830d840903774154ca0c1f27ec
   RNZipArchive: ef9451b849c45a29509bf44e65b788829ab07801
+  SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
+  SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   sqlite3: 02d1f07eaaa01f80a1c16b4b31dfcbb3345ee01a
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef
@@ -2035,6 +2067,6 @@ SPEC CHECKSUMS:
   Yoga: 950bbfd7e6f04790fdb51149ed51df41f329fcc8
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: a555e3bf20e7a7fbd521747ca919066410e3af18
+PODFILE CHECKSUM: faf338f6b9b723ac762519a2d1ba0e7314d95755
 
 COCOAPODS: 1.16.2

--- a/ios/RNVCIClientModule.m
+++ b/ios/RNVCIClientModule.m
@@ -54,7 +54,5 @@ RCT_EXTERN_METHOD(sendIssuerTrustResponseFromJS:(BOOL)isTrusted)
 // Sends token response JSON back to native side (in response to onRequestTokenResponse)
 RCT_EXTERN_METHOD(sendTokenResponseFromJS:(NSString *)tokenResponseJson)
 
-// Required by React Native
-RCT_EXTERN_METHOD(requiresMainQueueSetup:(BOOL)isRequired)
 
 @end

--- a/ios/RNVCIClientModule.swift
+++ b/ios/RNVCIClientModule.swift
@@ -67,7 +67,7 @@ class RNVCIClientModule: NSObject, RCTBridgeModule {
 
         let clientMeta = try parseClientMetadata(from: clientMetadata)
 
-        let response = try await vciClient.fetchCredentialUsingCredentialOffer(
+        let response = try await vciClient.fetchCredentialsUsingCredentialOffer(
           credentialOffer: credentialOffer,
           clientMetadata: clientMeta,
           getTxCode: { inputMode, description, length in
@@ -81,8 +81,8 @@ class RNVCIClientModule: NSObject, RCTBridgeModule {
           getTokenResponse: { tokenRequest in
             try await self.getTokenResponseHook(tokenRequest: tokenRequest)
           },
-          getProofJwt: { credentialIssuer, cNonce, algos in
-            try await self.getProofContinuationHook(
+          getProofs: { credentialIssuer, cNonce, algos in
+            try await self.getProofsContinuationHook(
               credentialIssuer: credentialIssuer,
               cNonce: cNonce,
               proofSigningAlgorithmsSupported: algos
@@ -96,7 +96,7 @@ class RNVCIClientModule: NSObject, RCTBridgeModule {
           }
         )
 
-        resolve(try response?.toJsonString())
+        resolve(try self.toSingleCredentialResponseJson(response))
       } catch {
         rejectVCIError(error, reject: reject)
       }
@@ -121,7 +121,7 @@ class RNVCIClientModule: NSObject, RCTBridgeModule {
 
         let clientMeta = try parseClientMetadata(from: clientMetadata)
 
-        let response = try await vciClient.fetchCredentialFromTrustedIssuer(
+        let response = try await vciClient.fetchCredentialsFromTrustedIssuer(
           credentialIssuer: credentialIssuer,
           credentialConfigurationId: credentialConfigurationId,
           clientMetadata: clientMeta,
@@ -129,8 +129,8 @@ class RNVCIClientModule: NSObject, RCTBridgeModule {
             try await self.getTokenResponseHook(tokenRequest: tokenRequest)
           },
           authorizationMethods: getSupportedAuthorizationMethods(signatureSuite: signatureSuite),
-          getProofJwt: { credentialIssuer, cNonce, algos in
-            try await self.getProofContinuationHook(
+          getProofs: { credentialIssuer, cNonce, algos in
+            try await self.getProofsContinuationHook(
               credentialIssuer: credentialIssuer,
               cNonce: cNonce,
               proofSigningAlgorithmsSupported: algos
@@ -138,7 +138,7 @@ class RNVCIClientModule: NSObject, RCTBridgeModule {
           },
           downloadTimeoutInMillis: 200000)
 
-        resolve(try response?.toJsonString())
+        resolve(try self.toSingleCredentialResponseJson(response))
       } catch {
         rejectVCIError(error, reject: reject)
       }
@@ -245,6 +245,20 @@ class RNVCIClientModule: NSObject, RCTBridgeModule {
     return try await withCheckedThrowingContinuation { continuation in
       self.pendingAuthCodeContinuation = { code in continuation.resume(returning: ["code": code]) }
     }
+  }
+
+  private func getProofsContinuationHook(
+    credentialIssuer: String,
+    cNonce: String?,
+    proofSigningAlgorithmsSupported: [String]
+  ) async throws -> CredentialRequestProofs {
+    let proof = try await getProofContinuationHook(
+      credentialIssuer: credentialIssuer,
+      cNonce: cNonce,
+      proofSigningAlgorithmsSupported: proofSigningAlgorithmsSupported
+    )
+
+    return CredentialRequestProofs(proofs: [proof])
   }
 
   private func getProofContinuationHook(
@@ -374,6 +388,30 @@ class RNVCIClientModule: NSObject, RCTBridgeModule {
     return try await withCheckedThrowingContinuation { continuation in
       self.pendingIssuerTrustDecision = { decision in continuation.resume(returning: decision) }
     }
+  }
+
+  private func toSingleCredentialResponseJson(
+    _ response: CredentialResponse
+  ) throws -> String {
+    guard let firstItem = response.credentials?.first else {
+      throw VCIClientException(code: "DOWNLOAD_FAILED", message: "No credential returned from issuer", serverErrorCode: nil, serverErrorDescription: nil)
+    }
+
+    var dict: [String: Any] = [
+      "credential": firstItem.credential?.value
+    ]
+    if let issuer = response.credentialIssuer {
+      dict["credentialIssuer"] = issuer
+    }
+    if let configId = response.credentialConfigurationId {
+      dict["credentialConfigurationId"] = configId
+    }
+
+    let data = try JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted)
+    guard let jsonString = String(data: data, encoding: .utf8) else {
+      throw VCIClientException(code: "DOWNLOAD_FAILED", message: "Failed to serialize credential response")
+    }
+    return jsonString
   }
 
   // MARK: - Receivers from JS

--- a/screens/Home/ViewVcModal.tsx
+++ b/screens/Home/ViewVcModal.tsx
@@ -82,6 +82,7 @@ export const ViewVcModal: React.FC<ViewVcModalProps> = props => {
   let [fields, setFields] = useState([]);
   const [wellknown, setWellknown] = useState(null);
   const [wellknownFieldsFlag, setWellknownFieldsFlag] = useState(false);
+  const [wellknownSettled, setWellknownSettled] = useState(false);
   const verifiableCredentialData = controller.verifiableCredentialData;
 
   const [loadingSvg, setLoadingSvg] = useState<boolean>(true);
@@ -131,6 +132,9 @@ export const ViewVcModal: React.FC<ViewVcModalProps> = props => {
       })
       .catch(error => {
         console.error('Error fetching well-known fields:', error);
+      })
+      .finally(() => {
+        setWellknownSettled(true);
       });
   }, [verifiableCredentialData?.wellKnown]);
 
@@ -198,7 +202,7 @@ export const ViewVcModal: React.FC<ViewVcModalProps> = props => {
         />
       )}
 
-      {!isVCLoaded(verifiableCredential) ? (
+      {!isVCLoaded(verifiableCredential) || !wellknownSettled ? (
         <ActivityIndicator />
       ) : (
         <VcDetailsContainer

--- a/screens/Home/__snapshots__/ViewVcModal.test.tsx.snap
+++ b/screens/Home/__snapshots__/ViewVcModal.test.tsx.snap
@@ -43,11 +43,7 @@ exports[`ViewVcModal should render when not visible 1`] = `
   isVisible={false}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;
 
 exports[`ViewVcModal should render when visible 1`] = `
@@ -93,11 +89,7 @@ exports[`ViewVcModal should render when visible 1`] = `
   isVisible={true}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;
 
 exports[`ViewVcModal should render with OTP error 1`] = `
@@ -143,11 +135,7 @@ exports[`ViewVcModal should render with OTP error 1`] = `
   isVisible={true}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;
 
 exports[`ViewVcModal should render with activeTab 1 (history) 1`] = `
@@ -193,11 +181,7 @@ exports[`ViewVcModal should render with activeTab 1 (history) 1`] = `
   isVisible={true}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;
 
 exports[`ViewVcModal should render with binding OTP state 1`] = `
@@ -243,11 +227,7 @@ exports[`ViewVcModal should render with binding OTP state 1`] = `
   isVisible={true}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;
 
 exports[`ViewVcModal should render with binding error 1`] = `
@@ -293,11 +273,7 @@ exports[`ViewVcModal should render with binding error 1`] = `
   isVisible={true}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;
 
 exports[`ViewVcModal should render with binding warning 1`] = `
@@ -343,11 +319,7 @@ exports[`ViewVcModal should render with binding warning 1`] = `
   isVisible={true}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;
 
 exports[`ViewVcModal should render with different flow type 1`] = `
@@ -358,11 +330,7 @@ exports[`ViewVcModal should render with different flow type 1`] = `
   isVisible={true}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;
 
 exports[`ViewVcModal should render with expired status 1`] = `
@@ -408,11 +376,7 @@ exports[`ViewVcModal should render with expired status 1`] = `
   isVisible={true}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;
 
 exports[`ViewVcModal should render with reverifying Vc 1`] = `
@@ -458,11 +422,7 @@ exports[`ViewVcModal should render with reverifying Vc 1`] = `
   isVisible={true}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;
 
 exports[`ViewVcModal should render with revoked status 1`] = `
@@ -508,11 +468,7 @@ exports[`ViewVcModal should render with revoked status 1`] = `
   isVisible={true}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;
 
 exports[`ViewVcModal should render with toast visible 1`] = `
@@ -558,11 +514,7 @@ exports[`ViewVcModal should render with toast visible 1`] = `
   isVisible={true}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;
 
 exports[`ViewVcModal should render with verification completed 1`] = `
@@ -608,11 +560,7 @@ exports[`ViewVcModal should render with verification completed 1`] = `
   isVisible={true}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;
 
 exports[`ViewVcModal should render with verification in progress 1`] = `
@@ -658,11 +606,7 @@ exports[`ViewVcModal should render with verification in progress 1`] = `
   isVisible={true}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;
 
 exports[`ViewVcModal should render with verification status banner 1`] = `
@@ -708,11 +652,7 @@ exports[`ViewVcModal should render with verification status banner 1`] = `
   isVisible={true}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;
 
 exports[`ViewVcModal should render with wallet binding in progress 1`] = `
@@ -758,11 +698,7 @@ exports[`ViewVcModal should render with wallet binding in progress 1`] = `
   isVisible={true}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;
 
 exports[`ViewVcModal should render with walletBindingResponse 1`] = `
@@ -808,9 +744,5 @@ exports[`ViewVcModal should render with walletBindingResponse 1`] = `
   isVisible={true}
   onDismiss={[Function]}
   testID="idDetailsHeader"
->
-  <View
-    testID="vcDetailsContainer"
-  />
-</View>
+/>
 `;

--- a/shared/openId4VCI/Utils.ts
+++ b/shared/openId4VCI/Utils.ts
@@ -151,7 +151,19 @@ export const getCredentialIssuersWellKnownConfig = async (
         wellknownResponse,
         credentialConfigurationId,
       );
-      if (
+      // OpenID4VCI Final 1.0: credential_metadata.claims is a flat array of
+      // claim description objects (Appendix B.2). Array order defines display
+      // order (Appendix B.3), superseding any legacy `order` field.
+      const normalizedClaims = matchingWellknownDetails.claims;
+      if (Array.isArray(normalizedClaims)) {
+        const extracted = normalizedClaims
+          .map(c => serializeClaimPath(c?.path, format))
+          .filter((p): p is string => !!p);
+        if (extracted.length > 0) {
+          fields = extracted;
+          wellknownFieldsFlag = true;
+        }
+      } else if (
         matchingWellknownDetails.order != null &&
         matchingWellknownDetails.order.length > 0
       ) {
@@ -221,6 +233,50 @@ export const getCredentialIssuersWellKnownConfig = async (
       wellknownFieldsFlag || matchingWellknownDetails?.order?.length > 0,
   };
 };
+// OpenID4VCI Final 1.0 moved per-credential `display` and `claims` into a
+// nested `credential_metadata` object. Lift them up so consumers can keep
+// reading `display`/`claims` directly. Legacy issuers (pre-Final-1.0) that
+// still put these at the top level continue to work via the `??` fallback.
+function normalizeCredentialMetadata(entry: any): any {
+  if (!entry || !entry.credential_metadata) return entry;
+  const cm = entry.credential_metadata;
+  return {
+    ...entry,
+    display: cm.display ?? entry.display,
+    claims: cm.claims ?? entry.claims,
+  };
+}
+
+// Serializes an Appendix C claims path pointer into the internal field key
+// convention used elsewhere in this codebase.
+//  - string segments → object keys
+//  - non-negative integer segments → preserved as digit strings; walkers
+//    resolve them via bracket access (works for both arrays and numeric
+//    map keys).
+//  - null segments (wildcard "all array elements") → dropped. Walkers
+//    auto-iterate remaining path across array values, so the pointer still
+//    resolves correctly.
+export function serializeClaimPath(
+  path: unknown,
+  format: string,
+): string | null {
+  if (!Array.isArray(path) || path.length === 0) return null;
+  const segs: string[] = [];
+  for (const p of path) {
+    if (typeof p === 'string') segs.push(p);
+    else if (typeof p === 'number' && Number.isInteger(p) && p >= 0)
+      segs.push(String(p));
+    // null (wildcard) is skipped — see comment above.
+  }
+  if (segs.length === 0) return null;
+  if (format === VCFormat.mso_mdoc) return segs.join('~');
+  if (format === VCFormat.ldp_vc || format === VCFormat.jwt_vc_json) {
+    const stripped = segs[0] === 'credentialSubject' ? segs.slice(1) : segs;
+    return stripped.length ? stripped.join('.') : null;
+  }
+  return segs.join('.');
+}
+
 const flattenClaimPaths = (
   claims: Record<string, any>,
   prefix = '',
@@ -639,7 +695,9 @@ export function getMatchingCredentialIssuerMetadata(
 ): any {
   for (const credentialTypeKey in wellknown.credential_configurations_supported) {
     if (credentialTypeKey === credentialConfigurationId) {
-      return wellknown.credential_configurations_supported[credentialTypeKey];
+      return normalizeCredentialMetadata(
+        wellknown.credential_configurations_supported[credentialTypeKey],
+      );
     }
   }
   console.error(


### PR DESCRIPTION
## Summary
- align the Android and iOS VCI bridges with the updated proofs and credential response APIs
- preserve the legacy credential JSON shape expected by the React Native layer
- support OpenID4VCI claim-path based field rendering for nested and array-backed claims and wait for well-known metadata before rendering VC details

## Testing
- not run
- pre-commit hook failed locally because lint-staged could not create its temporary git index stash due to low disk space on the machine

fixes #3812

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential field extraction and display across formats with better nested-object and array handling.
  * Enhanced well-known metadata parsing and claim-path serialization for more accurate field mapping.

* **New Features**
  * Modal UI now shows a loading indicator until credential details and well-known fields are fully ready.

* **Chores**
  * Updated native credential-fetching behavior and adjusted Android/iOS build/package settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->