### PR TITLE
fix(app): Update credentail Registry for  reduce launch delay

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 # eg . npm build android:newlogic --reset-cache
 
 #MIMOTO_HOST=http://mock.mimoto.newlogic.dev
-MIMOTO_HOST=https://api.qa-inji1.mosip.net
+MIMOTO_HOST=https://api.qainji.mosip.net
 
 ESIGNET_HOST=https://esignet.qa-inji.mosip.net
 

--- a/.talismanrc
+++ b/.talismanrc
@@ -211,7 +211,7 @@ fileignoreconfig:
 - filename: screens/Home/IntroSlidersScreen.tsx
   checksum: 9880724461b194db7651737576ad2fd2db9cf3b4e732747f59be422a7ff4e4a1
 - filename: .env
-  checksum: ac76b852842c44ff5dac96c1fa5061e569bea4f54b3080d869a9dc25abd17991
+  checksum: adaba979277161534c4f20dd34740be9fb84cbed8a3466f143b629b3c979c223
 - filename: machines/VCItemMachine/VCItemMachine.typegen.ts
   checksum: 850b5d02636bef9e286fc0fbc4ffffbd38068f332c319302a906496f4bc1c8a1
 - filename: machines/VerifiableCredential/VCItemMachine/VCItemModel.ts


### PR DESCRIPTION
## INJI-Mobile app startup fix

> Older credential registry was decomissoned resulting in app trying to fetch it and fallback to cached value which caused the app delay in startup

## Issue ticket number and link

> Example : [Issue-2400](https://github.com/inji/inji-wallet/issues/2400)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API endpoint configuration to point to the correct MOSIP service endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->