### PR TITLE
[INJIVER-1628] fix: domain of ldp_vp proof to hold clientId

### DIFF
--- a/ios/Inji.xcodeproj/project.pbxproj
+++ b/ios/Inji.xcodeproj/project.pbxproj
@@ -1184,8 +1184,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/inji/inji-openid4vp-ios-swift.git";
 			requirement = {
-				kind = exactVersion;
-				version = 0.7.0;
+				branch = "release-0.7.x";
+				kind = branch;
 			};
 		};
 		C3F18B1B2E320C9A007DBE73 /* XCRemoteSwiftPackageReference "inji-vci-client-ios-swift" */ = {

--- a/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -76,10 +76,10 @@
     {
       "identity" : "inji-openid4vp-ios-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/inji/inji-openid4vp-ios-swift",
+      "location" : "https://github.com/inji/inji-openid4vp-ios-swift.git",
       "state" : {
-        "revision" : "38e12ead6805da5cc2e214f065a5451f699e91dc",
-        "version" : "0.7.0"
+        "branch" : "release-0.7.x",
+        "revision" : "7a1574b4aaddc56b1d76614e889c5febf06afa74"
       }
     },
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the OpenID4VP Swift package dependency to track the release branch instead of using a pinned fixed version. This change enables more flexible and timely dependency updates, allowing the application to receive improvements and bug fixes from the library more promptly while maintaining stability through carefully controlled branch-based version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->