### PR TITLE
chore: prepare 0.22.1 release

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -115,7 +115,7 @@ android {
         applicationId 'io.mosip.residentapp'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionName "0.22.0"
+        versionName "0.22.1"
         versionCode 1
         manifestPlaceholders = [
                 APP_NAME             : APP_NAME,

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -74,7 +74,7 @@ lane :android_build_internal do
   git_commit = sh('git rev-parse --short HEAD').strip
   git_branch = sh('git rev-parse --abbrev-ref HEAD').strip
 
-  versionName = "0.22.0-#{git_commit}-#{git_branch}"
+  versionName = "0.22.1-#{git_commit}-#{git_branch}"
 
   gradle(task: "clean bundle#{APP_FLAVOR}Release")
   upload_to_play_store(

--- a/ios/Inji.xcodeproj/project.pbxproj
+++ b/ios/Inji.xcodeproj/project.pbxproj
@@ -932,7 +932,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.22.0;
+				MARKETING_VERSION = 0.22.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -971,7 +971,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.22.0;
+				MARKETING_VERSION = 0.22.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -980,8 +980,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = io.mosip.inji.wallet.mobileid;
 				PRODUCT_NAME = Inji;
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore io.mosip.inji.wallet.mobileid";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore io.mosip.inji.wallet.mobileid";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -115,7 +115,7 @@ platform :ios do
     match(
       type: 'appstore',
       app_identifier: "#{generate_app_bundle_id}",
-      git_basic_authorization: Base64.strict_encode64("#{GIT_AUTHORIZATION}"),
+      git_basic_authorization: "#{GIT_AUTHORIZATION}",
       readonly: false,
       keychain_name: keychain_name,
       keychain_password: keychain_password,
@@ -123,18 +123,29 @@ platform :ios do
     )
 
     profile_mapping = Actions.lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING]
+    profile_name = profile_mapping[generate_app_bundle_id] || profile_mapping[generate_app_bundle_id.to_sym]
+
+    UI.message("Using provisioning profile: #{profile_name}")
+
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: "Inji.xcodeproj",
+      team_id: "V2ABX7953Z",
+      profile_name: profile_name,
+      code_sign_identity: "Apple Distribution",
+      targets: ["Inji"],
+      build_configurations: ["Release"]
+    )
 
     gym(
       configuration: "Release",
       workspace: "Inji.xcworkspace",
       scheme: "Inji",
       export_method: "app-store",
-      output_directory: "./fastlane/Inji_artifacts", 
+      output_directory: "./fastlane/Inji_artifacts",
       output_name: "#{generate_app_name}.ipa",
       export_options: {
-        provisioningProfiles: {
-          "#{generate_app_bundle_id}" => "match AppStore #{generate_app_bundle_id}"
-        }
+        provisioningProfiles: profile_mapping
       }
     )
   
@@ -191,7 +202,7 @@ platform :ios do
     match(
       type: 'appstore',
       app_identifier: "#{generate_app_bundle_id}",
-      git_basic_authorization: Base64.strict_encode64("#{GIT_AUTHORIZATION}"),
+      git_basic_authorization: "#{GIT_AUTHORIZATION}",
       readonly: false,
       keychain_name: keychain_name,
       keychain_password: keychain_password,
@@ -199,17 +210,27 @@ platform :ios do
     )
 
     profile_mapping = Actions.lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING]
+    profile_name = profile_mapping[generate_app_bundle_id] || profile_mapping[generate_app_bundle_id.to_sym]
+
+    UI.message("Using provisioning profile: #{profile_name}")
+
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: "Inji.xcodeproj",
+      team_id: "V2ABX7953Z",
+      profile_name: profile_name,
+      code_sign_identity: "Apple Distribution",
+      targets: ["Inji"],
+      build_configurations: ["Release"]
+    )
 
     gym(
       configuration: "Release",
       workspace: "Inji.xcworkspace",
       scheme: "Inji",
       export_method: "app-store",
-
       export_options: {
-        provisioningProfiles: {
-          "#{generate_app_bundle_id}" => "match AppStore #{generate_app_bundle_id}"
-        }
+        provisioningProfiles: profile_mapping
       }
     )
 

--- a/ios/fastlane/Matchfile
+++ b/ios/fastlane/Matchfile
@@ -1,5 +1,4 @@
-git_url("https://github.com/inji/inji-ios-priv")
+git_url("https://github.com/inji/ios-certificates")
 storage_mode("git")
 
 type("appstore") # The default type, can be: appstore, adhoc, enterprise or development
-


### PR DESCRIPTION
## Summary

- Applies the iOS CI publishing fixes for Fastlane signing/profile handling.
- Updates the iOS match repository to `inji/ios-certificates`.
- Bumps the patch release app version from `0.22.0` to `0.22.1`.

