### PR TITLE
chore: update ovp swift package to 0.7.1

### DIFF
--- a/ios/Inji.xcodeproj/project.pbxproj
+++ b/ios/Inji.xcodeproj/project.pbxproj
@@ -1178,8 +1178,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/inji/inji-openid4vp-ios-swift.git";
 			requirement = {
-				branch = "release-0.7.x";
-				kind = branch;
+				kind = exactVersion;
+				version = 0.7.1;
 			};
 		};
 		C3F18B1B2E320C9A007DBE73 /* XCRemoteSwiftPackageReference "inji-vci-client-ios-swift" */ = {

--- a/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/inji/inji-openid4vp-ios-swift.git",
       "state" : {
-        "branch" : "release-0.7.x",
-        "revision" : "7a1574b4aaddc56b1d76614e889c5febf06afa74"
+        "revision" : "7a1574b4aaddc56b1d76614e889c5febf06afa74",
+        "version" : "0.7.1"
       }
     },
     {


### PR DESCRIPTION
- OVP library update for VP holder not populated as Holder Id of VC in ldp_vp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to pinned versions for improved stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->