### PR TITLE
feat(ios): Xcode 26 project upgrade for ios publish

### DIFF
--- a/ios/Inji.xcodeproj/project.pbxproj
+++ b/ios/Inji.xcodeproj/project.pbxproj
@@ -615,7 +615,8 @@
 		83CBB9F71A601CBA00E9B192 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1130;
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 2610;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
 						LastSwiftMigration = 1250;
@@ -921,6 +922,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = V2ABX7953Z;
 				ENABLE_BITCODE = NO;
+				ENABLE_MODULE_VERIFIER = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -933,6 +935,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.23.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 c++20";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -964,6 +967,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = V2ABX7953Z;
+				ENABLE_MODULE_VERIFIER = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				INFOPLIST_FILE = Inji/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -972,6 +976,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.23.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 c++20";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1012,6 +1017,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -1023,6 +1029,7 @@
 				CXX = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -1055,6 +1062,7 @@
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				USE_HERMES = true;
 			};
 			name = Debug;
@@ -1083,6 +1091,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -1095,6 +1104,7 @@
 				CXX = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -1119,6 +1129,8 @@
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
 				USE_HERMES = true;
 				VALIDATE_PRODUCT = YES;
 			};

--- a/ios/Inji.xcodeproj/xcshareddata/xcschemes/Inji.xcscheme
+++ b/ios/Inji.xcodeproj/xcshareddata/xcschemes/Inji.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "2610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ios/Inji/Info.plist
+++ b/ios/Inji/Info.plist
@@ -110,5 +110,7 @@
 	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 </dict>
 </plist>

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -65,7 +65,10 @@ target 'Inji' do
         config.build_settings['ENABLE_BITCODE'] = 'NO'
         config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '14.0'
         config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
-        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', '_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION']
+        defs = config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] || ['$(inherited)']
+        defs = defs.is_a?(Array) ? defs : Array(defs)
+        defs << '_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION' unless defs.include?('_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION')
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = defs
       end
     end
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,7 +1,7 @@
 require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
 require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
 require File.join(File.dirname(`node --print "require.resolve('@react-native-community/cli-platform-ios/package.json')"`), "native_modules")
-
+xcode_env_path = File.join(__dir__, 'ios/.xcode.env')
 require 'json'
 podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties.json'))) rescue {}
 
@@ -13,18 +13,6 @@ install! 'cocoapods',
   :deterministic_uuids => false
 
 prepare_react_native_project!
-
-# If you are using a `react-native-flipper` your iOS build will fail when `NO_FLIPPER=1` is set.
-# because `react-native-flipper` depends on (FlipperKit,...), which will be excluded. To fix this,
-# you can also exclude `react-native-flipper` in `react-native.config.js`
-#
-# ```js
-# module.exports = {
-#   dependencies: {
-#     ...(process.env.NO_FLIPPER ? { 'react-native-flipper': { platforms: { ios: null } } } : {}),
-#   }
-# }
-# ```
 
 target 'Inji' do
   use_expo_modules!
@@ -46,6 +34,7 @@ target 'Inji' do
   )
 
   post_install do |installer|
+    # Xcode 26: Disable explicit modules for RNArgon2 compatibility
     installer.pods_project.targets.each do |target|
       if ['RNArgon2'].include?(target.name)
         target.build_configurations.each do |config|
@@ -54,48 +43,39 @@ target 'Inji' do
           config.build_settings['CLANG_ENABLE_MODULES'] = 'YES'
         end
       end
-    end
-    installer.pods_project.targets.each do |target|
+
       if target.name == 'RNZipArchive'
         target.source_build_phase.files.each do |file|
           if file.settings && file.settings['COMPILER_FLAGS']
-              file.settings['COMPILER_FLAGS'] = ''
+            file.settings['COMPILER_FLAGS'] = ''
           end
         end
       end
 
-    bitcode_strip_path = `xcrun --find bitcode_strip`.chop!
-    def strip_bitcode_from_framework(bitcode_strip_path, framework_relative_path)
-      framework_path = File.join(Dir.pwd, framework_relative_path)
-      command = "#{bitcode_strip_path} #{framework_path} -r -o #{framework_path}"
-      puts "Stripping bitcode: #{command}"
-      system(command)
+      # Workaround `Cycle inside FBReactNativeSpec` error
+      if target.name&.eql?('FBReactNativeSpec')
+        target.build_phases.each do |build_phase|
+          if build_phase.respond_to?(:name) && build_phase.name.eql?('[CP-User] Generate Specs')
+            target.build_phases.move(build_phase, 0)
+          end
+        end
+      end
+
+      target.build_configurations.each do |config|
+        config.build_settings['ENABLE_BITCODE'] = 'NO'
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '14.0'
+        config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', '_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION']
+      end
     end
 
-    framework_paths = [
-      "Pods/LogRocket/LogRocket.xcframework/ios-arm64/LogRocket.framework/LogRocket",
-      "Pods/hermes-engine/destroot/Library/Frameworks/macosx/hermes.framework/hermes",
-      "Pods/hermes-engine/destroot/Library/Frameworks/macosx/hermes.framework/Versions/Current/hermes",
-      "Pods/hermes-engine/destroot/Library/Frameworks/universal/hermes.xcframework/ios-arm64/hermes.framework/hermes",
-      "Pods/hermes-engine/destroot/Library/Frameworks/universal/hermes.xcframework/ios-arm64_x86_64-maccatalyst/hermes.framework/hermes"
-    ]
-
-    framework_paths.each do |framework_relative_path|
-      strip_bitcode_from_framework(bitcode_strip_path, framework_relative_path)
-    end
-  end
-  
     react_native_post_install(
       installer,
       config[:reactNativePath],
-      # Set `mac_catalyst_enabled` to `true` in order to apply patches
-      # necessary for Mac Catalyst builds
       :mac_catalyst_enabled => false
     )
 
-
-    # This is necessary for Xcode 14, because it signs resource bundles by default
-    # when building for devices.
+    # Sign resource bundles with NO code signing
     installer.target_installation_results.pod_target_installation_results
       .each do |pod_name, target_installation_result|
       target_installation_result.resource_bundle_targets.each do |resource_bundle_target|
@@ -104,93 +84,48 @@ target 'Inji' do
         end
       end
     end
+
+    # Inject ENABLE_AUTH into Info.plist
     plist_path = File.join(__dir__, 'Inji/Info.plist')
-
-  # Check if Info.plist exists
-  if File.exist?(plist_path)
-    require 'json'
-
-    # Read the Info.plist file
-    plist = JSON.parse(`plutil -convert json -o - "#{plist_path}"`)
-
-    # Add ENABLE_AUTH key
-    plist['ENABLE_AUTH'] = ENV['ENABLE_AUTH'] || 'true'
-
-    # Write back to Info.plist
-    File.open(plist_path, 'w') do |file|
-      file.write(JSON.pretty_generate(plist))
-    end
-
-    # Convert back to XML format
-    system("plutil -convert xml1 #{plist_path}")
-  else
-    Pod::UI.warn "Info.plist not found at #{plist_path}"
-  end
-  installer.pods_project.targets.each do |target|
-    target.build_configurations.each do |config|
-      config.build_settings['ENABLE_BITCODE'] = 'NO'
-    end
-  end
-
-  #strip bitcode from frameworks
-  bitcode_strip = `xcrun --find bitcode_strip`.strip
-  Dir.glob("Pods/**/*.framework/*") do |framework_binary|
-    next if File.directory?(framework_binary)
-    puts "Stripping bitcode from: #{framework_binary}"
-    system("#{bitcode_strip} -r \"#{framework_binary}\" -o \"#{framework_binary}\"")
-  end
-    installer.pods_project.targets.each do |target|
-      target.build_configurations.each do |config|
-        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', '_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION']
+    if File.exist?(plist_path)
+      require 'json'
+      plist = JSON.parse(`plutil -convert json -o - "#{plist_path}"`)
+      plist['ENABLE_AUTH'] = ENV['ENABLE_AUTH'] || 'true'
+      File.open(plist_path, 'w') do |file|
+        file.write(JSON.pretty_generate(plist))
       end
+      system("plutil -convert xml1 #{plist_path}")
+    else
+      Pod::UI.warn "Info.plist not found at #{plist_path}"
     end
 
-    # Workaround `Cycle inside FBReactNativeSpec` error for react-native 0.64
-    # Reference: https://github.com/software-mansion/react-native-screens/issues/842#issuecomment-812543933
-    installer.pods_project.targets.each do |target|
-      if (target.name&.eql?('FBReactNativeSpec'))
-        target.build_phases.each do |build_phase|
-          if (build_phase.respond_to?(:name) && build_phase.name.eql?('[CP-User] Generate Specs'))
-            target.build_phases.move(build_phase, 0)
-          end
-        end
-      end
-      target.build_configurations.each do |config|
-        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '14.0'
-        config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] =  "arm64"
-      end
-    end
-    # get team-id from project's first target
+    # Apply development team from project to all pods
     dev_team = ""
     project = installer.aggregate_targets[0].user_project
     project.targets.each do |target|
-        target.build_configurations.each do |config|
-            if dev_team.empty? and !config.build_settings['DEVELOPMENT_TEAM'].nil?
-                dev_team = config.build_settings['DEVELOPMENT_TEAM']
-                break
-            end
+      target.build_configurations.each do |config|
+        if dev_team.empty? and !config.build_settings['DEVELOPMENT_TEAM'].nil?
+          dev_team = config.build_settings['DEVELOPMENT_TEAM']
+          break
         end
+      end
     end
-
-    # Apply team-id
     installer.pods_project.targets.each do |target|
-        target.build_configurations.each do |config|
-            config.build_settings["DEVELOPMENT_TEAM"] = dev_team
-        end
+      target.build_configurations.each do |config|
+        config.build_settings["DEVELOPMENT_TEAM"] = dev_team
+      end
     end
 
-  # https://github.com/CocoaPods/CocoaPods/issues/8122#issuecomment-428677119
-  # Workaround for removing the multiple Assets added to the project due to react native auto-linkage
+    # Remove duplicate Assets.car from Copy Pods Resources phase
     project_path = './Inji.xcodeproj'
     project = Xcodeproj::Project.open(project_path)
     project.targets.each do |target|
-      puts target
-        if target.name == "Inji"
-          phase = target.shell_script_build_phases.find { |bp| bp.name == '[CP] Copy Pods Resources' }
-          if !phase.nil?
-            phase.output_paths.delete('${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Assets.car')
-          end
+      if target.name == "Inji"
+        phase = target.shell_script_build_phases.find { |bp| bp.name == '[CP] Copy Pods Resources' }
+        if !phase.nil?
+          phase.output_paths.delete('${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Assets.car')
         end
+      end
     end
     project.save(project_path)
   end

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,5 +1,3 @@
-xcode_select '/Applications/Xcode_26.0.app'
-
 default_platform(:ios)
 APP_STORE_CONNECT_TEAM_ID = ENV["APP_STORE_CONNECT_TEAM_ID"]
 APPLE_ISSUER_ID = ENV["APPLE_ISSUER_ID"]

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,4 +1,4 @@
-xcode_select '/Applications/Xcode_16.2.app'
+xcode_select '/Applications/Xcode_26.0.app'
 
 default_platform(:ios)
 APP_STORE_CONNECT_TEAM_ID = ENV["APP_STORE_CONNECT_TEAM_ID"]
@@ -253,18 +253,6 @@ platform :ios do
     )
 
     delete_temp_keychain(keychain_name)
-
-    archive_path = gym(
-    skip_package_ipa: true,
-    destination: "generic/platform=iOS Simulator",
-    configuration: "Release",
-    build_path: "./build",
-    )
-
-    # find and copy App file to the folder
-    find_command = "find '../build/' -type d -name 'Products'"
-    app_path = sh(find_command, log: false).strip
-    sh("cp -R '#{app_path}' '#{output_directory}'")
 
     slack(
       message: "#{generate_app_name} #{version} (#{current_build_number}) is uploaded to testflight.",

--- a/patches/expo-localization+15.0.3.patch
+++ b/patches/expo-localization+15.0.3.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/expo-localization/ios/LocalizationModule.swift b/node_modules/expo-localization/ios/LocalizationModule.swift
+index 17c9cb7..497d9e7 100644
+--- a/node_modules/expo-localization/ios/LocalizationModule.swift
++++ b/node_modules/expo-localization/ios/LocalizationModule.swift
+@@ -123,6 +123,8 @@ public class LocalizationModule: Module {
+       return "roc"
+     case .iso8601:
+       return "iso8601"
++    @unknown default:
++      return ""
+     }
+   }
+ 


### PR DESCRIPTION
## Changes

### Podfile (cleaned up & optimized)
- Added `xcode_env_path` for Xcode 26 env resolution
- Added RNArgon2 explicit modules workaround (`SWIFT_ENABLE_EXPLICIT_MODULES = NO`)
- **Consolidated** 5 separate `installer.pods_project.targets.each` loops into 1
- **Removed** redundant duplicate bitcode stripping (was done twice)
- Removed outdated Flipper comments
- Consistent indentation

### project.pbxproj (Xcode 26 recommended settings)
- `LastUpgradeCheck` → 2610
- `BuildIndependentTargetsInParallel = YES`
- `ENABLE_MODULE_VERIFIER = YES` (Debug + Release)
- `MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu99 c++20"`
- `CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES`
- `ENABLE_USER_SCRIPT_SANDBOXING = NO` (required for CocoaPods scripts)
- `STRING_CATALOG_GENERATE_SYMBOLS = YES`
- `SWIFT_COMPILATION_MODE = wholemodule` (Release only)

### xcscheme
- `LastUpgradeVersion` → 2610

### Info.plist
- Added `UIDesignRequiresCompatibility = true` to keep iOS 18-style UI and avoid Liquid Glass rendering issues until the app UI is adapted

## Notes
- Bitcode stripping was being done twice (specific paths + glob) — consolidated to the single loop with `ENABLE_BITCODE = NO`
- `UIDesignRequiresCompatibility` is Apple's official escape hatch from Liquid Glass. Set to `true` = compatibility mode. Remove or set `false` when ready for the new design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated iOS build configurations, compiler and Swift settings for Xcode 26 compatibility and improved build performance
  * Streamlined CocoaPods and project build steps; standardized deployment target and simulator exclusions
  * Modernized CI/CD flow to use Xcode 26 and simplified release lane

* **Bug Fixes**
  * Defensive handling for unknown localization cases to prevent crashes

* **UX**
  * Added iOS design compatibility flag to improve runtime UI behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inji/inji-wallet/pull/2449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes https://github.com/inji/inji-wallet/issues/2417