### PR TITLE
fix: skip bluetooth permission for online ovp scan

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -293,7 +293,7 @@ dependencies {
         exclude group: 'io.inji', module: 'inji-openid4vp-aar'
     }
     implementation("com.google.code.gson:gson:2.10.1")
-    implementation("io.inji:vcverifier-aar:1.8.0-SNAPSHOT") {
+    implementation("io.inji:vcverifier-aar:1.8.1") {
         exclude group: 'org.bouncycastle', module: 'bcpkix-jdk15on'
     }
 

--- a/machines/bleShare/scan/scanActions.ts
+++ b/machines/bleShare/scan/scanActions.ts
@@ -151,6 +151,10 @@ export const ScanActions = (model: any) => {
       readyForBluetoothStateCheck: () => true,
     }),
 
+    resetReadyForBluetoothStateCheck: model.assign({
+      readyForBluetoothStateCheck: () => false,
+    }),
+
     setBleError: assign({
       bleError: (_context, event) => event.bleError,
     }),

--- a/machines/bleShare/scan/scanMachine.ts
+++ b/machines/bleShare/scan/scanMachine.ts
@@ -340,7 +340,6 @@ export const scanMachine =
           after: {
             DESTROY_TIMEOUT: {
               target: '#scan.connecting',
-              actions: [],
               internal: false,
             },
           },

--- a/machines/bleShare/scan/scanMachine.ts
+++ b/machines/bleShare/scan/scanMachine.ts
@@ -376,6 +376,7 @@ export const scanMachine =
             'registerLoggers',
             'clearUri',
             'resetFaceCaptureBannerStatus',
+            'resetReadyForBluetoothStateCheck',
           ],
           on: {
             SCAN: [

--- a/machines/bleShare/scan/scanMachine.ts
+++ b/machines/bleShare/scan/scanMachine.ts
@@ -115,7 +115,7 @@ export const scanMachine =
                 target: 'restrictSharingVc',
               },
               {
-                target: 'startPermissionCheck',
+                target: 'checkFaceAuthConsent',
               },
             ],
           },
@@ -248,7 +248,7 @@ export const scanMachine =
                   target: '#scan.checkingLocationState',
                 },
                 {
-                  target: '#scan.clearingConnection',
+                  target: '#scan.clearingConnectionBeforeBleConnect',
                 },
               ],
             },
@@ -278,7 +278,7 @@ export const scanMachine =
                   target: '#scan.checkingLocationState',
                 },
                 {
-                  target: '#scan.clearingConnection',
+                  target: '#scan.clearingConnectionBeforeBleConnect',
                 },
               ],
             },
@@ -327,6 +327,24 @@ export const scanMachine =
             },
           },
         },
+        clearingConnectionBeforeBleConnect: {
+          invoke: {
+            src: 'disconnect',
+          },
+          on: {
+            DISCONNECT: {
+              target: '#scan.connecting',
+              internal: false,
+            },
+          },
+          after: {
+            DESTROY_TIMEOUT: {
+              target: '#scan.connecting',
+              actions: [],
+              internal: false,
+            },
+          },
+        },
         checkFaceAuthConsent: {
           entry: 'getFaceAuthConsent',
           on: {
@@ -362,7 +380,7 @@ export const scanMachine =
           on: {
             SCAN: [
               {
-                target: 'connecting',
+                target: 'startPermissionCheck',
                 cond: 'isOpenIdQr',
                 actions: ['sendVcSharingStartEvent', 'setUri'],
               },
@@ -874,7 +892,7 @@ export const scanMachine =
               },
               on: {
                 LOCATION_ENABLED: {
-                  target: '#scan.clearingConnection',
+                  target: '#scan.clearingConnectionBeforeBleConnect',
                 },
                 LOCATION_DISABLED: {
                   target: 'requestToEnableLocation',
@@ -887,7 +905,7 @@ export const scanMachine =
               },
               on: {
                 LOCATION_ENABLED: {
-                  target: '#scan.clearingConnection',
+                  target: '#scan.clearingConnectionBeforeBleConnect',
                 },
                 LOCATION_DISABLED: {
                   target: 'denied',

--- a/machines/bleShare/scan/scanMachine.typegen.ts
+++ b/machines/bleShare/scan/scanMachine.typegen.ts
@@ -1,141 +1,418 @@
+// This file was automatically generated. Edits will be overwritten
 
-  // This file was automatically generated. Edits will be overwritten
-
-  export interface Typegen0 {
-        '@@xstate/typegen': true;
-        internalEvents: {
-          "": { type: "" };
-"done.invoke.QrLogin": { type: "done.invoke.QrLogin"; data: unknown; __tip: "See the XState TS docs to learn how to strongly type this." };
-"done.invoke.scan.checkStorage:invocation[0]": { type: "done.invoke.scan.checkStorage:invocation[0]"; data: unknown; __tip: "See the XState TS docs to learn how to strongly type this." };
-"xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection": { type: "xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection" };
-"xstate.init": { type: "xstate.init" };
-"xstate.stop": { type: "xstate.stop" };
-        };
-        invokeSrcNameMap: {
-          "checkBluetoothPermission": "done.invoke.scan.checkBluetoothPermission.checking:invocation[0]";
-"checkBluetoothState": "done.invoke.scan.checkBluetoothState.checking:invocation[0]" | "done.invoke.scan.recheckBluetoothState.checking:invocation[0]";
-"checkLocationPermission": "done.invoke.scan.checkingLocationState.checkingPermissionStatus:invocation[0]";
-"checkLocationStatus": "done.invoke.scan.checkingLocationState.checkLocationService:invocation[0]";
-"checkNearByDevicesPermission": "done.invoke.scan.checkNearbyDevicesPermission.checking:invocation[0]";
-"checkStorageAvailability": "done.invoke.scan.checkStorage:invocation[0]";
-"disconnect": "done.invoke.scan.clearingConnection:invocation[0]" | "done.invoke.scan.disconnectDevice:invocation[0]" | "done.invoke.scan.reviewing.disconnect:invocation[0]";
-"monitorConnection": "done.invoke.scan:invocation[0]";
-"requestBluetooth": "done.invoke.scan.checkBluetoothState.requesting:invocation[0]";
-"requestNearByDevicesPermission": "done.invoke.scan.checkNearbyDevicesPermission.requesting:invocation[0]";
-"requestToEnableLocationPermission": "done.invoke.scan.checkingLocationState.requestToEnableLocation:invocation[0]";
-"sendVc": "done.invoke.scan.reviewing.sendingVc:invocation[0]";
-"startConnection": "done.invoke.scan.connecting:invocation[0]";
-        };
-        missingImplementations: {
-          actions: "clearUri" | "enableLocation" | "getFaceAuthConsent" | "loadMetaDataToMemory" | "loadVCDataToMemory" | "logFailedVerification" | "logShared" | "openAppPermission" | "openBluetoothSettings" | "refreshVCs" | "registerLoggers" | "removeLoggers" | "resetAuthorizationRequest" | "resetBleError" | "resetFaceCaptureBannerStatus" | "resetFlowType" | "resetIsOVPViaDeepLink" | "resetIsQrLoginViaDeepLink" | "resetLinkCode" | "resetOpenID4VPFlowType" | "resetSelectedVc" | "resetShowQuickShareSuccessBanner" | "sendBLEConnectionErrorEvent" | "sendScanData" | "sendVCShareFlowCancelEndEvent" | "sendVCShareFlowTimeoutEndEvent" | "sendVPScanData" | "sendVcShareSuccessEvent" | "sendVcSharingStartEvent" | "setAuthRequestFromDeepLink" | "setBleError" | "setFlowType" | "setIsOVPViaDeepLink" | "setIsQrLoginViaDeepLink" | "setLinkCode" | "setLinkCodeFromDeepLink" | "setOpenId4VPFlowType" | "setOpenId4VPRef" | "setQrLoginRef" | "setQuickShareData" | "setReadyForBluetoothStateCheck" | "setReceiverInfo" | "setSelectedVc" | "setSenderInfo" | "setShareLogTypeUnverified" | "setShareLogTypeVerified" | "setShowFaceAuthConsent" | "setShowQuickShareSuccessBanner" | "setUri" | "storeLoginItem" | "storeShowFaceAuthConsent" | "storingActivityLog" | "updateFaceCaptureBannerStatus" | "updateShowFaceAuthConsent";
-          delays: never;
-          guards: "isFlowTypeDeepLink" | "isFlowTypeMiniViewShare" | "isFlowTypeMiniViewShareWithSelfie" | "isFlowTypeSimpleShare" | "isIOS" | "isMinimumStorageRequiredForAuditEntryReached" | "isOVPViaDeepLink" | "isOnlineSharing" | "isOpenIdQr" | "isQrLogin" | "isQrLoginViaDeepLinking" | "isQuickShare" | "showFaceAuthConsentScreen" | "uptoAndroid11";
-          services: "checkBluetoothPermission" | "checkBluetoothState" | "checkLocationPermission" | "checkLocationStatus" | "checkNearByDevicesPermission" | "checkStorageAvailability" | "disconnect" | "monitorConnection" | "requestBluetooth" | "requestNearByDevicesPermission" | "requestToEnableLocationPermission" | "sendVc" | "startConnection";
-        };
-        eventsCausingActions: {
-          "clearUri": "";
-"enableLocation": "ALLOWED" | "LOCATION_REQUEST";
-"getFaceAuthConsent": "DISCONNECT" | "DISMISS" | "START_PERMISSION_CHECK" | "xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection";
-"loadMetaDataToMemory": "SCAN";
-"loadVCDataToMemory": "STORE_RESPONSE";
-"logFailedVerification": "FACE_INVALID";
-"logShared": "VC_ACCEPTED";
-"openAppPermission": "GOTO_SETTINGS" | "LOCATION_REQUEST";
-"openBluetoothSettings": "GOTO_SETTINGS";
-"refreshVCs": "STORE_RESPONSE";
-"registerLoggers": "";
-"removeLoggers": "" | "DISCONNECT" | "DISMISS" | "DISMISS_QUICK_SHARE_BANNER" | "OVP_VIA_DEEP_LINK" | "QRLOGIN_VIA_DEEP_LINK" | "RESET" | "SCREEN_BLUR" | "xstate.init";
-"resetAuthorizationRequest": "RESET";
-"resetBleError": "DISMISS";
-"resetFaceCaptureBannerStatus": "" | "ACCEPT_REQUEST" | "CLOSE_BANNER";
-"resetFlowType": "DISCONNECT" | "DISMISS" | "DISMISS_QUICK_SHARE_BANNER" | "GOTO_HISTORY" | "OVP_VIA_DEEP_LINK" | "QRLOGIN_VIA_DEEP_LINK" | "RESET" | "SCREEN_BLUR" | "xstate.init";
-"resetIsOVPViaDeepLink": "DISMISS" | "RESET";
-"resetIsQrLoginViaDeepLink": "DISMISS" | "RESET";
-"resetLinkCode": "BLE_ERROR" | "DISMISS" | "DISMISS_QUICK_SHARE_BANNER" | "OVP_VIA_DEEP_LINK" | "QRLOGIN_VIA_DEEP_LINK" | "RESET" | "SCREEN_BLUR" | "SCREEN_FOCUS" | "SELECT_VC" | "xstate.stop";
-"resetOpenID4VPFlowType": "CANCEL" | "DISMISS" | "RESET" | "RETRY" | "SCREEN_BLUR";
-"resetSelectedVc": "DISCONNECT" | "DISMISS" | "DISMISS_QUICK_SHARE_BANNER" | "GOTO_HISTORY" | "OVP_VIA_DEEP_LINK" | "QRLOGIN_VIA_DEEP_LINK" | "RESET" | "SCREEN_BLUR" | "xstate.init";
-"resetShowQuickShareSuccessBanner": "DISMISS" | "DISMISS_QUICK_SHARE_BANNER";
-"sendBLEConnectionErrorEvent": "BLE_ERROR";
-"sendScanData": "" | "SCAN";
-"sendVCShareFlowCancelEndEvent": "CANCEL";
-"sendVCShareFlowTimeoutEndEvent": "CANCEL" | "RETRY";
-"sendVPScanData": "" | "SCAN";
-"sendVcShareSuccessEvent": "VC_ACCEPTED";
-"sendVcSharingStartEvent": "SCAN";
-"setAuthRequestFromDeepLink": "OVP_VIA_DEEP_LINK" | "SCAN";
-"setBleError": "BLE_ERROR";
-"setFlowType": "SELECT_VC";
-"setIsOVPViaDeepLink": "OVP_VIA_DEEP_LINK";
-"setIsQrLoginViaDeepLink": "QRLOGIN_VIA_DEEP_LINK";
-"setLinkCode": "SCAN";
-"setLinkCodeFromDeepLink": "QRLOGIN_VIA_DEEP_LINK";
-"setOpenId4VPFlowType": "" | "OVP_VIA_DEEP_LINK" | "SCAN";
-"setOpenId4VPRef": "CANCEL" | "DISCONNECT" | "DISMISS" | "DISMISS_QUICK_SHARE_BANNER" | "OVP_VIA_DEEP_LINK" | "QRLOGIN_VIA_DEEP_LINK" | "RESET" | "RETRY" | "SCREEN_BLUR" | "SCREEN_FOCUS" | "SELECT_VC" | "xstate.init";
-"setQrLoginRef": "QRLOGIN_VIA_DEEP_LINK" | "SCAN";
-"setQuickShareData": "SCAN";
-"setReadyForBluetoothStateCheck": "BLUETOOTH_PERMISSION_ENABLED";
-"setReceiverInfo": "CONNECTED";
-"setSelectedVc": "SELECT_VC";
-"setSenderInfo": "CONNECTED";
-"setShareLogTypeUnverified": "ACCEPT_REQUEST" | "CHECK_FLOW_TYPE";
-"setShareLogTypeVerified": "FACE_VALID";
-"setShowFaceAuthConsent": "FACE_VERIFICATION_CONSENT";
-"setShowQuickShareSuccessBanner": "STORE_RESPONSE";
-"setUri": "SCAN";
-"storeLoginItem": "done.invoke.QrLogin";
-"storeShowFaceAuthConsent": "FACE_VERIFICATION_CONSENT";
-"storingActivityLog": "STORE_RESPONSE";
-"updateFaceCaptureBannerStatus": "FACE_VALID";
-"updateShowFaceAuthConsent": "STORE_RESPONSE";
-        };
-        eventsCausingDelays: {
-          "CONNECTION_TIMEOUT": "SCAN";
-"DESTROY_TIMEOUT": "" | "DISMISS" | "LOCATION_ENABLED" | "RETRY";
-"SHARING_TIMEOUT": "ACCEPT_REQUEST" | "CHECK_FLOW_TYPE" | "FACE_VALID";
-        };
-        eventsCausingGuards: {
-          "isFlowTypeDeepLink": "START_PERMISSION_CHECK";
-"isFlowTypeMiniViewShare": "CHECK_FLOW_TYPE";
-"isFlowTypeMiniViewShareWithSelfie": "CHECK_FLOW_TYPE" | "DISMISS";
-"isFlowTypeSimpleShare": "CANCEL" | "CHECK_FLOW_TYPE" | "DISMISS" | "RETRY";
-"isIOS": "BLUETOOTH_STATE_DISABLED" | "START_PERMISSION_CHECK";
-"isMinimumStorageRequiredForAuditEntryReached": "done.invoke.scan.checkStorage:invocation[0]";
-"isOVPViaDeepLink": "";
-"isOnlineSharing": "SCAN";
-"isOpenIdQr": "SCAN";
-"isQrLogin": "SCAN";
-"isQrLoginViaDeepLinking": "" | "STORE_RESPONSE";
-"isQuickShare": "SCAN";
-"showFaceAuthConsentScreen": "" | "VERIFY_AND_ACCEPT_REQUEST";
-"uptoAndroid11": "" | "START_PERMISSION_CHECK";
-        };
-        eventsCausingServices: {
-          "OpenId4VP": "" | "SCAN";
-"QrLogin": "" | "SCAN";
-"checkBluetoothPermission": "" | "BLUETOOTH_STATE_DISABLED" | "NEARBY_ENABLED" | "START_PERMISSION_CHECK";
-"checkBluetoothState": "" | "APP_ACTIVE";
-"checkLocationPermission": "LOCATION_ENABLED";
-"checkLocationStatus": "" | "APP_ACTIVE" | "LOCATION_REQUEST";
-"checkNearByDevicesPermission": "APP_ACTIVE" | "START_PERMISSION_CHECK";
-"checkStorageAvailability": "CANCEL" | "DISMISS" | "OVP_VIA_DEEP_LINK" | "QRLOGIN_VIA_DEEP_LINK" | "RESET" | "RETRY" | "SCREEN_FOCUS" | "SELECT_VC";
-"disconnect": "" | "DISMISS" | "LOCATION_ENABLED" | "RETRY" | "SCREEN_BLUR";
-"monitorConnection": "DISMISS" | "OVP_VIA_DEEP_LINK" | "QRLOGIN_VIA_DEEP_LINK" | "SCREEN_BLUR" | "xstate.init";
-"requestBluetooth": "BLUETOOTH_STATE_DISABLED";
-"requestNearByDevicesPermission": "NEARBY_DISABLED";
-"requestToEnableLocationPermission": "LOCATION_DISABLED";
-"sendVc": "ACCEPT_REQUEST" | "CHECK_FLOW_TYPE" | "FACE_VALID";
-"startConnection": "SCAN";
-        };
-        matchesStates: "bluetoothDenied" | "bluetoothPermissionDenied" | "checkBluetoothPermission" | "checkBluetoothPermission.checking" | "checkBluetoothPermission.enabled" | "checkBluetoothState" | "checkBluetoothState.checking" | "checkBluetoothState.enabled" | "checkBluetoothState.requesting" | "checkFaceAuthConsent" | "checkForDeepLinkFlow" | "checkNearbyDevicesPermission" | "checkNearbyDevicesPermission.checking" | "checkNearbyDevicesPermission.enabled" | "checkNearbyDevicesPermission.requesting" | "checkStorage" | "checkingLocationState" | "checkingLocationState.LocationPermissionRationale" | "checkingLocationState.checkLocationService" | "checkingLocationState.checkingPermissionStatus" | "checkingLocationState.denied" | "checkingLocationState.disabled" | "checkingLocationState.requestToEnableLocation" | "clearingConnection" | "connecting" | "connecting.inProgress" | "connecting.timeout" | "decodeQuickShareData" | "disconnectDevice" | "disconnected" | "findingConnection" | "handlingBleError" | "inactive" | "invalid" | "loadVCS" | "loadVCS.idle" | "loadVCS.navigatingToHome" | "nearByDevicesPermissionDenied" | "recheckBluetoothState" | "recheckBluetoothState.checking" | "recheckBluetoothState.enabled" | "restrictSharingVc" | "reviewing" | "reviewing.accepted" | "reviewing.cancelling" | "reviewing.checkFaceAuthConsentForMiniView" | "reviewing.disconnect" | "reviewing.faceVerificationConsent" | "reviewing.idle" | "reviewing.invalidIdentity" | "reviewing.navigateToHistory" | "reviewing.rejected" | "reviewing.selectingVc" | "reviewing.sendingVc" | "reviewing.sendingVc.inProgress" | "reviewing.sendingVc.sent" | "reviewing.sendingVc.timeout" | "reviewing.verifyingIdentity" | "showQrLogin" | "showQrLogin.idle" | "showQrLogin.navigatingToHistory" | "showQrLogin.navigatingToHome" | "showQrLogin.storing" | "startPermissionCheck" | "startVPSharing" | "startVPSharing.inProgress" | "startVPSharing.showError" | "startVPSharing.success" | "startVPSharing.timeout" | { "checkBluetoothPermission"?: "checking" | "enabled";
-"checkBluetoothState"?: "checking" | "enabled" | "requesting";
-"checkNearbyDevicesPermission"?: "checking" | "enabled" | "requesting";
-"checkingLocationState"?: "LocationPermissionRationale" | "checkLocationService" | "checkingPermissionStatus" | "denied" | "disabled" | "requestToEnableLocation";
-"connecting"?: "inProgress" | "timeout";
-"loadVCS"?: "idle" | "navigatingToHome";
-"recheckBluetoothState"?: "checking" | "enabled";
-"reviewing"?: "accepted" | "cancelling" | "checkFaceAuthConsentForMiniView" | "disconnect" | "faceVerificationConsent" | "idle" | "invalidIdentity" | "navigateToHistory" | "rejected" | "selectingVc" | "sendingVc" | "verifyingIdentity" | { "sendingVc"?: "inProgress" | "sent" | "timeout"; };
-"showQrLogin"?: "idle" | "navigatingToHistory" | "navigatingToHome" | "storing";
-"startVPSharing"?: "inProgress" | "showError" | "success" | "timeout"; };
-        tags: never;
-      }
-  
+export interface Typegen0 {
+  '@@xstate/typegen': true;
+  internalEvents: {
+    '': {type: ''};
+    'done.invoke.QrLogin': {
+      type: 'done.invoke.QrLogin';
+      data: unknown;
+      __tip: 'See the XState TS docs to learn how to strongly type this.';
+    };
+    'done.invoke.scan.checkStorage:invocation[0]': {
+      type: 'done.invoke.scan.checkStorage:invocation[0]';
+      data: unknown;
+      __tip: 'See the XState TS docs to learn how to strongly type this.';
+    };
+    'xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection': {
+      type: 'xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection';
+    };
+    'xstate.after(DESTROY_TIMEOUT)#scan.clearingConnectionBeforeBleConnect': {
+      type: 'xstate.after(DESTROY_TIMEOUT)#scan.clearingConnectionBeforeBleConnect';
+    };
+    'xstate.init': {type: 'xstate.init'};
+    'xstate.stop': {type: 'xstate.stop'};
+  };
+  invokeSrcNameMap: {
+    checkBluetoothPermission: 'done.invoke.scan.checkBluetoothPermission.checking:invocation[0]';
+    checkBluetoothState:
+      | 'done.invoke.scan.checkBluetoothState.checking:invocation[0]'
+      | 'done.invoke.scan.recheckBluetoothState.checking:invocation[0]';
+    checkLocationPermission: 'done.invoke.scan.checkingLocationState.checkingPermissionStatus:invocation[0]';
+    checkLocationStatus: 'done.invoke.scan.checkingLocationState.checkLocationService:invocation[0]';
+    checkNearByDevicesPermission: 'done.invoke.scan.checkNearbyDevicesPermission.checking:invocation[0]';
+    checkStorageAvailability: 'done.invoke.scan.checkStorage:invocation[0]';
+    disconnect:
+      | 'done.invoke.scan.clearingConnectionBeforeBleConnect:invocation[0]'
+      | 'done.invoke.scan.clearingConnection:invocation[0]'
+      | 'done.invoke.scan.disconnectDevice:invocation[0]'
+      | 'done.invoke.scan.reviewing.disconnect:invocation[0]';
+    monitorConnection: 'done.invoke.scan:invocation[0]';
+    requestBluetooth: 'done.invoke.scan.checkBluetoothState.requesting:invocation[0]';
+    requestNearByDevicesPermission: 'done.invoke.scan.checkNearbyDevicesPermission.requesting:invocation[0]';
+    requestToEnableLocationPermission: 'done.invoke.scan.checkingLocationState.requestToEnableLocation:invocation[0]';
+    sendVc: 'done.invoke.scan.reviewing.sendingVc:invocation[0]';
+    startConnection: 'done.invoke.scan.connecting:invocation[0]';
+  };
+  missingImplementations: {
+    actions:
+      | 'clearUri'
+      | 'enableLocation'
+      | 'getFaceAuthConsent'
+      | 'loadMetaDataToMemory'
+      | 'loadVCDataToMemory'
+      | 'logFailedVerification'
+      | 'logShared'
+      | 'openAppPermission'
+      | 'openBluetoothSettings'
+      | 'refreshVCs'
+      | 'registerLoggers'
+      | 'removeLoggers'
+      | 'resetAuthorizationRequest'
+      | 'resetBleError'
+      | 'resetFaceCaptureBannerStatus'
+      | 'resetFlowType'
+      | 'resetIsOVPViaDeepLink'
+      | 'resetIsQrLoginViaDeepLink'
+      | 'resetLinkCode'
+      | 'resetOpenID4VPFlowType'
+      | 'resetSelectedVc'
+      | 'resetShowQuickShareSuccessBanner'
+      | 'sendBLEConnectionErrorEvent'
+      | 'sendScanData'
+      | 'sendVCShareFlowCancelEndEvent'
+      | 'sendVCShareFlowTimeoutEndEvent'
+      | 'sendVPScanData'
+      | 'sendVcShareSuccessEvent'
+      | 'sendVcSharingStartEvent'
+      | 'setAuthRequestFromDeepLink'
+      | 'setBleError'
+      | 'setFlowType'
+      | 'setIsOVPViaDeepLink'
+      | 'setIsQrLoginViaDeepLink'
+      | 'setLinkCode'
+      | 'setLinkCodeFromDeepLink'
+      | 'setOpenId4VPFlowType'
+      | 'setOpenId4VPRef'
+      | 'setQrLoginRef'
+      | 'setQuickShareData'
+      | 'setReadyForBluetoothStateCheck'
+      | 'setReceiverInfo'
+      | 'setSelectedVc'
+      | 'setSenderInfo'
+      | 'setShareLogTypeUnverified'
+      | 'setShareLogTypeVerified'
+      | 'setShowFaceAuthConsent'
+      | 'setShowQuickShareSuccessBanner'
+      | 'setUri'
+      | 'storeLoginItem'
+      | 'storeShowFaceAuthConsent'
+      | 'storingActivityLog'
+      | 'updateFaceCaptureBannerStatus'
+      | 'updateShowFaceAuthConsent';
+    delays: never;
+    guards:
+      | 'isFlowTypeDeepLink'
+      | 'isFlowTypeMiniViewShare'
+      | 'isFlowTypeMiniViewShareWithSelfie'
+      | 'isFlowTypeSimpleShare'
+      | 'isIOS'
+      | 'isMinimumStorageRequiredForAuditEntryReached'
+      | 'isOVPViaDeepLink'
+      | 'isOnlineSharing'
+      | 'isOpenIdQr'
+      | 'isQrLogin'
+      | 'isQrLoginViaDeepLinking'
+      | 'isQuickShare'
+      | 'showFaceAuthConsentScreen'
+      | 'uptoAndroid11';
+    services:
+      | 'checkBluetoothPermission'
+      | 'checkBluetoothState'
+      | 'checkLocationPermission'
+      | 'checkLocationStatus'
+      | 'checkNearByDevicesPermission'
+      | 'checkStorageAvailability'
+      | 'disconnect'
+      | 'monitorConnection'
+      | 'requestBluetooth'
+      | 'requestNearByDevicesPermission'
+      | 'requestToEnableLocationPermission'
+      | 'sendVc'
+      | 'startConnection';
+  };
+  eventsCausingActions: {
+    clearUri: '';
+    enableLocation: 'ALLOWED' | 'LOCATION_REQUEST';
+    getFaceAuthConsent:
+      | 'DISCONNECT'
+      | 'DISMISS'
+      | 'START_PERMISSION_CHECK'
+      | 'xstate.after(DESTROY_TIMEOUT)#scan.clearingConnection';
+    loadMetaDataToMemory: 'SCAN';
+    loadVCDataToMemory: 'STORE_RESPONSE';
+    logFailedVerification: 'FACE_INVALID';
+    logShared: 'VC_ACCEPTED';
+    openAppPermission: 'GOTO_SETTINGS' | 'LOCATION_REQUEST';
+    openBluetoothSettings: 'GOTO_SETTINGS';
+    refreshVCs: 'STORE_RESPONSE';
+    registerLoggers: '';
+    removeLoggers:
+      | ''
+      | 'DISCONNECT'
+      | 'DISMISS'
+      | 'DISMISS_QUICK_SHARE_BANNER'
+      | 'OVP_VIA_DEEP_LINK'
+      | 'QRLOGIN_VIA_DEEP_LINK'
+      | 'RESET'
+      | 'SCREEN_BLUR'
+      | 'xstate.init';
+    resetAuthorizationRequest: 'RESET';
+    resetBleError: 'DISMISS';
+    resetFaceCaptureBannerStatus: '' | 'ACCEPT_REQUEST' | 'CLOSE_BANNER';
+    resetFlowType:
+      | 'DISCONNECT'
+      | 'DISMISS'
+      | 'DISMISS_QUICK_SHARE_BANNER'
+      | 'GOTO_HISTORY'
+      | 'OVP_VIA_DEEP_LINK'
+      | 'QRLOGIN_VIA_DEEP_LINK'
+      | 'RESET'
+      | 'SCREEN_BLUR'
+      | 'xstate.init';
+    resetIsOVPViaDeepLink: 'DISMISS' | 'RESET';
+    resetIsQrLoginViaDeepLink: 'DISMISS' | 'RESET';
+    resetLinkCode:
+      | 'BLE_ERROR'
+      | 'DISMISS'
+      | 'DISMISS_QUICK_SHARE_BANNER'
+      | 'OVP_VIA_DEEP_LINK'
+      | 'QRLOGIN_VIA_DEEP_LINK'
+      | 'RESET'
+      | 'SCREEN_BLUR'
+      | 'SCREEN_FOCUS'
+      | 'SELECT_VC'
+      | 'xstate.stop';
+    resetOpenID4VPFlowType:
+      | 'CANCEL'
+      | 'DISMISS'
+      | 'RESET'
+      | 'RETRY'
+      | 'SCREEN_BLUR';
+    resetSelectedVc:
+      | 'DISCONNECT'
+      | 'DISMISS'
+      | 'DISMISS_QUICK_SHARE_BANNER'
+      | 'GOTO_HISTORY'
+      | 'OVP_VIA_DEEP_LINK'
+      | 'QRLOGIN_VIA_DEEP_LINK'
+      | 'RESET'
+      | 'SCREEN_BLUR'
+      | 'xstate.init';
+    resetShowQuickShareSuccessBanner: 'DISMISS' | 'DISMISS_QUICK_SHARE_BANNER';
+    sendBLEConnectionErrorEvent: 'BLE_ERROR';
+    sendScanData: '' | 'SCAN';
+    sendVCShareFlowCancelEndEvent: 'CANCEL';
+    sendVCShareFlowTimeoutEndEvent: 'CANCEL' | 'RETRY';
+    sendVPScanData: '' | 'SCAN';
+    sendVcShareSuccessEvent: 'VC_ACCEPTED';
+    sendVcSharingStartEvent: 'SCAN';
+    setAuthRequestFromDeepLink: 'OVP_VIA_DEEP_LINK' | 'SCAN';
+    setBleError: 'BLE_ERROR';
+    setFlowType: 'SELECT_VC';
+    setIsOVPViaDeepLink: 'OVP_VIA_DEEP_LINK';
+    setIsQrLoginViaDeepLink: 'QRLOGIN_VIA_DEEP_LINK';
+    setLinkCode: 'SCAN';
+    setLinkCodeFromDeepLink: 'QRLOGIN_VIA_DEEP_LINK';
+    setOpenId4VPFlowType: '' | 'OVP_VIA_DEEP_LINK' | 'SCAN';
+    setOpenId4VPRef:
+      | 'CANCEL'
+      | 'DISCONNECT'
+      | 'DISMISS'
+      | 'DISMISS_QUICK_SHARE_BANNER'
+      | 'OVP_VIA_DEEP_LINK'
+      | 'QRLOGIN_VIA_DEEP_LINK'
+      | 'RESET'
+      | 'RETRY'
+      | 'SCREEN_BLUR'
+      | 'SCREEN_FOCUS'
+      | 'SELECT_VC'
+      | 'xstate.init';
+    setQrLoginRef: 'QRLOGIN_VIA_DEEP_LINK' | 'SCAN';
+    setQuickShareData: 'SCAN';
+    setReadyForBluetoothStateCheck: 'BLUETOOTH_PERMISSION_ENABLED';
+    setReceiverInfo: 'CONNECTED';
+    setSelectedVc: 'SELECT_VC';
+    setSenderInfo: 'CONNECTED';
+    setShareLogTypeUnverified: 'ACCEPT_REQUEST' | 'CHECK_FLOW_TYPE';
+    setShareLogTypeVerified: 'FACE_VALID';
+    setShowFaceAuthConsent: 'FACE_VERIFICATION_CONSENT';
+    setShowQuickShareSuccessBanner: 'STORE_RESPONSE';
+    setUri: 'SCAN';
+    storeLoginItem: 'done.invoke.QrLogin';
+    storeShowFaceAuthConsent: 'FACE_VERIFICATION_CONSENT';
+    storingActivityLog: 'STORE_RESPONSE';
+    updateFaceCaptureBannerStatus: 'FACE_VALID';
+    updateShowFaceAuthConsent: 'STORE_RESPONSE';
+  };
+  eventsCausingDelays: {
+    CONNECTION_TIMEOUT: 'SCAN';
+    DESTROY_TIMEOUT: '' | 'DISMISS' | 'LOCATION_ENABLED' | 'RETRY';
+    SHARING_TIMEOUT: 'ACCEPT_REQUEST' | 'CHECK_FLOW_TYPE' | 'FACE_VALID';
+  };
+  eventsCausingGuards: {
+    isFlowTypeDeepLink: 'START_PERMISSION_CHECK';
+    isFlowTypeMiniViewShare: 'CHECK_FLOW_TYPE';
+    isFlowTypeMiniViewShareWithSelfie: 'CHECK_FLOW_TYPE' | 'DISMISS';
+    isFlowTypeSimpleShare: 'CANCEL' | 'CHECK_FLOW_TYPE' | 'DISMISS' | 'RETRY';
+    isIOS: 'BLUETOOTH_STATE_DISABLED' | 'START_PERMISSION_CHECK';
+    isMinimumStorageRequiredForAuditEntryReached: 'done.invoke.scan.checkStorage:invocation[0]';
+    isOVPViaDeepLink: '';
+    isOnlineSharing: 'SCAN';
+    isOpenIdQr: 'SCAN';
+    isQrLogin: 'SCAN';
+    isQrLoginViaDeepLinking: '' | 'STORE_RESPONSE';
+    isQuickShare: 'SCAN';
+    showFaceAuthConsentScreen: '' | 'VERIFY_AND_ACCEPT_REQUEST';
+    uptoAndroid11: '' | 'START_PERMISSION_CHECK';
+  };
+  eventsCausingServices: {
+    OpenId4VP: '' | 'SCAN';
+    QrLogin: '' | 'SCAN';
+    checkBluetoothPermission:
+      | ''
+      | 'BLUETOOTH_STATE_DISABLED'
+      | 'NEARBY_ENABLED'
+      | 'START_PERMISSION_CHECK';
+    checkBluetoothState: '' | 'APP_ACTIVE';
+    checkLocationPermission: 'LOCATION_ENABLED';
+    checkLocationStatus: '' | 'APP_ACTIVE' | 'LOCATION_REQUEST';
+    checkNearByDevicesPermission: 'APP_ACTIVE' | 'START_PERMISSION_CHECK';
+    checkStorageAvailability:
+      | 'CANCEL'
+      | 'DISMISS'
+      | 'OVP_VIA_DEEP_LINK'
+      | 'QRLOGIN_VIA_DEEP_LINK'
+      | 'RESET'
+      | 'RETRY'
+      | 'SCREEN_FOCUS'
+      | 'SELECT_VC';
+    disconnect:
+      | ''
+      | 'BLUETOOTH_STATE_ENABLED'
+      | 'DISMISS'
+      | 'LOCATION_ENABLED'
+      | 'RETRY'
+      | 'SCREEN_BLUR';
+    monitorConnection:
+      | 'DISMISS'
+      | 'OVP_VIA_DEEP_LINK'
+      | 'QRLOGIN_VIA_DEEP_LINK'
+      | 'SCREEN_BLUR'
+      | 'xstate.init';
+    requestBluetooth: 'BLUETOOTH_STATE_DISABLED';
+    requestNearByDevicesPermission: 'NEARBY_DISABLED';
+    requestToEnableLocationPermission: 'LOCATION_DISABLED';
+    sendVc: 'ACCEPT_REQUEST' | 'CHECK_FLOW_TYPE' | 'FACE_VALID';
+    startConnection:
+      | 'DISCONNECT'
+      | 'xstate.after(DESTROY_TIMEOUT)#scan.clearingConnectionBeforeBleConnect';
+  };
+  matchesStates:
+    | 'bluetoothDenied'
+    | 'bluetoothPermissionDenied'
+    | 'checkBluetoothPermission'
+    | 'checkBluetoothPermission.checking'
+    | 'checkBluetoothPermission.enabled'
+    | 'checkBluetoothState'
+    | 'checkBluetoothState.checking'
+    | 'checkBluetoothState.enabled'
+    | 'checkBluetoothState.requesting'
+    | 'checkFaceAuthConsent'
+    | 'checkForDeepLinkFlow'
+    | 'checkNearbyDevicesPermission'
+    | 'checkNearbyDevicesPermission.checking'
+    | 'checkNearbyDevicesPermission.enabled'
+    | 'checkNearbyDevicesPermission.requesting'
+    | 'checkStorage'
+    | 'checkingLocationState'
+    | 'checkingLocationState.LocationPermissionRationale'
+    | 'checkingLocationState.checkLocationService'
+    | 'checkingLocationState.checkingPermissionStatus'
+    | 'checkingLocationState.denied'
+    | 'checkingLocationState.disabled'
+    | 'checkingLocationState.requestToEnableLocation'
+    | 'clearingConnection'
+    | 'clearingConnectionBeforeBleConnect'
+    | 'connecting'
+    | 'connecting.inProgress'
+    | 'connecting.timeout'
+    | 'decodeQuickShareData'
+    | 'disconnectDevice'
+    | 'disconnected'
+    | 'findingConnection'
+    | 'handlingBleError'
+    | 'inactive'
+    | 'invalid'
+    | 'loadVCS'
+    | 'loadVCS.idle'
+    | 'loadVCS.navigatingToHome'
+    | 'nearByDevicesPermissionDenied'
+    | 'recheckBluetoothState'
+    | 'recheckBluetoothState.checking'
+    | 'recheckBluetoothState.enabled'
+    | 'restrictSharingVc'
+    | 'reviewing'
+    | 'reviewing.accepted'
+    | 'reviewing.cancelling'
+    | 'reviewing.checkFaceAuthConsentForMiniView'
+    | 'reviewing.disconnect'
+    | 'reviewing.faceVerificationConsent'
+    | 'reviewing.idle'
+    | 'reviewing.invalidIdentity'
+    | 'reviewing.navigateToHistory'
+    | 'reviewing.rejected'
+    | 'reviewing.selectingVc'
+    | 'reviewing.sendingVc'
+    | 'reviewing.sendingVc.inProgress'
+    | 'reviewing.sendingVc.sent'
+    | 'reviewing.sendingVc.timeout'
+    | 'reviewing.verifyingIdentity'
+    | 'showQrLogin'
+    | 'showQrLogin.idle'
+    | 'showQrLogin.navigatingToHistory'
+    | 'showQrLogin.navigatingToHome'
+    | 'showQrLogin.storing'
+    | 'startPermissionCheck'
+    | 'startVPSharing'
+    | 'startVPSharing.inProgress'
+    | 'startVPSharing.showError'
+    | 'startVPSharing.success'
+    | 'startVPSharing.timeout'
+    | {
+        checkBluetoothPermission?: 'checking' | 'enabled';
+        checkBluetoothState?: 'checking' | 'enabled' | 'requesting';
+        checkNearbyDevicesPermission?: 'checking' | 'enabled' | 'requesting';
+        checkingLocationState?:
+          | 'LocationPermissionRationale'
+          | 'checkLocationService'
+          | 'checkingPermissionStatus'
+          | 'denied'
+          | 'disabled'
+          | 'requestToEnableLocation';
+        connecting?: 'inProgress' | 'timeout';
+        loadVCS?: 'idle' | 'navigatingToHome';
+        recheckBluetoothState?: 'checking' | 'enabled';
+        reviewing?:
+          | 'accepted'
+          | 'cancelling'
+          | 'checkFaceAuthConsentForMiniView'
+          | 'disconnect'
+          | 'faceVerificationConsent'
+          | 'idle'
+          | 'invalidIdentity'
+          | 'navigateToHistory'
+          | 'rejected'
+          | 'selectingVc'
+          | 'sendingVc'
+          | 'verifyingIdentity'
+          | {sendingVc?: 'inProgress' | 'sent' | 'timeout'};
+        showQrLogin?:
+          | 'idle'
+          | 'navigatingToHistory'
+          | 'navigatingToHome'
+          | 'storing';
+        startVPSharing?: 'inProgress' | 'showError' | 'success' | 'timeout';
+      };
+  tags: never;
+}

--- a/machines/bleShare/scan/scanServices.test.ts
+++ b/machines/bleShare/scan/scanServices.test.ts
@@ -226,7 +226,7 @@ describe('ScanServices', () => {
   it('checkNearByDevicesPermission calls NEARBY_ENABLED when granted', async () => {
     const {checkMultiple} = require('react-native-permissions');
     checkMultiple.mockResolvedValueOnce({
-      bt_adv: 'granted',
+      bt_scan: 'granted',
       bt_connect: 'granted',
     });
     const callback = jest.fn();
@@ -238,7 +238,7 @@ describe('ScanServices', () => {
   it('checkNearByDevicesPermission calls NEARBY_DISABLED when not granted', async () => {
     const {checkMultiple} = require('react-native-permissions');
     checkMultiple.mockResolvedValueOnce({
-      bt_adv: 'denied',
+      bt_scan: 'denied',
       bt_connect: 'denied',
     });
     const callback = jest.fn();

--- a/machines/bleShare/scan/scanServices.test.ts
+++ b/machines/bleShare/scan/scanServices.test.ts
@@ -11,6 +11,7 @@ jest.mock('react-native-bluetooth-state-manager', () => ({
 }));
 jest.mock('react-native-permissions', () => ({
   check: jest.fn().mockResolvedValue('granted'),
+  request: jest.fn().mockResolvedValue('granted'),
   checkMultiple: jest.fn().mockResolvedValue({}),
   requestMultiple: jest.fn().mockResolvedValue({}),
   PERMISSIONS: {
@@ -129,8 +130,8 @@ describe('ScanServices', () => {
   it('checkBluetoothPermission calls BLUETOOTH_PERMISSION_DENIED on iOS when denied', async () => {
     const {isIOS} = require('../../../shared/constants');
     isIOS.mockReturnValue(true);
-    const {check} = require('react-native-permissions');
-    check.mockResolvedValueOnce('denied');
+    const {request} = require('react-native-permissions');
+    request.mockResolvedValueOnce('denied');
     const callback = jest.fn();
     const fn = services.checkBluetoothPermission();
     await fn(callback);

--- a/machines/bleShare/scan/scanServices.ts
+++ b/machines/bleShare/scan/scanServices.ts
@@ -2,10 +2,10 @@ import {isLocationEnabled} from 'react-native-device-info';
 import {isMinimumStorageLimitReached} from '../../../shared/storage';
 import BluetoothStateManager from 'react-native-bluetooth-state-manager';
 import {
-  check,
   checkMultiple,
   PERMISSIONS,
   PermissionStatus,
+  request,
   requestMultiple,
   RESULTS,
 } from 'react-native-permissions';
@@ -29,7 +29,7 @@ export const ScanServices = (model: any) => {
         let response: PermissionStatus = RESULTS.GRANTED;
 
         if (isIOS()) {
-          response = await check(PERMISSIONS.IOS.BLUETOOTH_PERIPHERAL);
+          response = await request(PERMISSIONS.IOS.BLUETOOTH_PERIPHERAL);
         }
 
         if (response === RESULTS.GRANTED) {

--- a/machines/bleShare/scan/scanServices.ts
+++ b/machines/bleShare/scan/scanServices.ts
@@ -1,5 +1,5 @@
 import {isLocationEnabled} from 'react-native-device-info';
-import  { isMinimumStorageLimitReached } from '../../../shared/storage';
+import {isMinimumStorageLimitReached} from '../../../shared/storage';
 import BluetoothStateManager from 'react-native-bluetooth-state-manager';
 import {
   check,
@@ -94,8 +94,7 @@ export const ScanServices = (model: any) => {
       ])
         .then(response => {
           if (
-            response[PERMISSIONS.ANDROID.BLUETOOTH_ADVERTISE] ===
-              RESULTS.GRANTED &&
+            response[PERMISSIONS.ANDROID.BLUETOOTH_SCAN] === RESULTS.GRANTED &&
             response[PERMISSIONS.ANDROID.BLUETOOTH_CONNECT] === RESULTS.GRANTED
           ) {
             callback(model.events.NEARBY_ENABLED());
@@ -169,11 +168,9 @@ export const ScanServices = (model: any) => {
           });
         }
       };
-      const { processedCredential, ...rest } = context.selectedVc;
+      const {processedCredential, ...rest} = context.selectedVc;
       const payload = JSON.stringify(rest);
-      wallet.sendData(
-        payload
-      );
+      wallet.sendData(payload);
       const subscription = subscribe(statusCallback);
       return () => subscription?.remove();
     },
@@ -188,7 +185,9 @@ export const ScanServices = (model: any) => {
     },
 
     checkStorageAvailability: () => async () => {
-      return Promise.resolve(isMinimumStorageLimitReached('minStorageRequiredForAuditEntry'));
+      return Promise.resolve(
+        isMinimumStorageLimitReached('minStorageRequiredForAuditEntry'),
+      );
     },
   };
 };

--- a/screens/Scan/ScanScreen.tsx
+++ b/screens/Scan/ScanScreen.tsx
@@ -202,11 +202,7 @@ export const ScanScreen: React.FC = () => {
     return (
       <Column crossAlign="center">
         <QrScanner
-          onQrFound={qr => {
-            if (!scanScreenController.isNoSharableVCs) {
-              scanScreenController.SCAN(qr);
-            }
-          }}
+          onQrFound={scanScreenController.SCAN}
           title={t('scanningGuide')}
         />
       </Column>

--- a/screens/Scan/ScanScreen.tsx
+++ b/screens/Scan/ScanScreen.tsx
@@ -54,6 +54,9 @@ export const ScanScreen: React.FC = () => {
   const {appService} = useContext(GlobalContext);
 
   useEffect(() => {
+    if (!scanScreenController.isReadyForBluetoothStateCheck) {
+      return;
+    }
     (async () => {
       await BluetoothStateManager.onStateChange(state => {
         if (state === 'PoweredOff') {
@@ -63,7 +66,7 @@ export const ScanScreen: React.FC = () => {
         }
       }, true);
     })();
-  }, [isBluetoothOn]);
+  }, [isBluetoothOn, scanScreenController.isReadyForBluetoothStateCheck]);
 
   // TODO(kludge): skip running this hook on every render
   useEffect(() => {
@@ -199,7 +202,11 @@ export const ScanScreen: React.FC = () => {
     return (
       <Column crossAlign="center">
         <QrScanner
-          onQrFound={scanScreenController.SCAN}
+          onQrFound={qr => {
+            if (!scanScreenController.isNoSharableVCs) {
+              scanScreenController.SCAN(qr);
+            }
+          }}
           title={t('scanningGuide')}
         />
       </Column>


### PR DESCRIPTION
## Summary
- allow the scan screen to open without Bluetooth/Nearby permission checks
- route online OpenID4VP QR scans directly to VP sharing
- keep BLE QR scans gated behind Bluetooth/Nearby/Location checks before connecting
- align Nearby Devices permission checks with the permissions requested

## Validation
- npx tsc --noEmit
- npm test -- --runInBand machines/bleShare/scan/scanActions.test.ts machines/bleShare/scan/scanGuards.test.ts machines/bleShare/scan/scanServices.test.ts machines/bleShare/scan/scanModel.test.ts
- npm test -- --runInBand machines/bleShare/scan/scanMachine.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked the Bluetooth scan/connect state flow with a new intermediate “clearing connection” step and updated routing after permission/storage steps.
  * Added a readiness reset for Bluetooth state checks and adjusted scan transitions to align with the new flow.
* **Bug Fixes**
  * Updated the Scan screen’s Bluetooth state listener to register only after controller readiness is confirmed.
* **Tests**
  * Refreshed permission mocks and expectations to match the revised request/denial and nearby-device permission logic.
* **Chores**
  * Updated an Android dependency version; reformatted autogenerated type definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->