### PR TITLE
feat(doc): add proposed dpop adr

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -284,7 +284,7 @@ fileignoreconfig:
 - filename: android/app/src/main/java/io/mosip/residentapp/InjiVciClientModule.java
   checksum: 17f55840bab193bc353034445ba4fce53e1ce466e95f616c15a1351f8d2f23bc
 - filename: ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
-  checksum: aa607dc5ca1df7c61739ab87768923f83e5acd81d5517ddcfd82f84d22e804ef
+  checksum: b1bd02573ba9c8976d7085bb9d0047a26e2c942498b0fa807cde873fe4184642
 - filename: injitest/src/main/resources/Vids.json
   checksum: 8bcffed7a6dd565ae695e1b29de0655e10bd5c5420af2718defd593a687b8817
 - filename: injitest/src/main/java/inji/utils/UpdateNetworkSettings.java

--- a/.talismanrc
+++ b/.talismanrc
@@ -638,7 +638,7 @@ fileignoreconfig:
 - filename: machines/Issuers/IssuersGuards.ts
   checksum: c306648f21ba2e717c286f45901741a018c0e04d6b21bc5b54ddc32346dc3130
 - filename: ios/Inji/Info.plist
-  checksum: 170ba8939993cbb1df97140a88ddc1e4c710d3a31f1be8ccd25621a4cf4bf059
+  checksum: 0efe36d93c367f449d6bd1dec8f3ce1bac341f00df4de266f1afdf7e6fcbaa42
 - filename: components/DeeplinkBanner.tsx
   checksum: 43322f48a27d3a3f8d8c38f39c3c88ddaa1940835f186acf60fb863fda70fd67
 - filename: machines/Issuers/IssuersActions.ts

--- a/.talismanrc
+++ b/.talismanrc
@@ -284,7 +284,7 @@ fileignoreconfig:
 - filename: android/app/src/main/java/io/mosip/residentapp/InjiVciClientModule.java
   checksum: 17f55840bab193bc353034445ba4fce53e1ce466e95f616c15a1351f8d2f23bc
 - filename: ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
-  checksum: b1bd02573ba9c8976d7085bb9d0047a26e2c942498b0fa807cde873fe4184642
+  checksum: aa607dc5ca1df7c61739ab87768923f83e5acd81d5517ddcfd82f84d22e804ef
 - filename: injitest/src/main/resources/Vids.json
   checksum: 8bcffed7a6dd565ae695e1b29de0655e10bd5c5420af2718defd593a687b8817
 - filename: injitest/src/main/java/inji/utils/UpdateNetworkSettings.java

--- a/android/app/src/main/java/io/mosip/residentapp/InjiVciClientModule.java
+++ b/android/app/src/main/java/io/mosip/residentapp/InjiVciClientModule.java
@@ -94,6 +94,15 @@ public class InjiVciClientModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void generateTokenDPoPProof(String dpopNonce, Promise promise) {
+    try {
+      promise.resolve(vciClient.generateTokenDPoPProof(dpopNonce));
+    } catch (Exception e) {
+      promise.reject("GENERATE_TOKEN_DPOP_PROOF_FAILED", e.getMessage(), e);
+    }
+  }
+
+  @ReactMethod
   public void getIssuerMetadata(String credentialIssuer, Promise promise) {
     new Thread(() -> {
       try {

--- a/android/app/src/main/java/io/mosip/residentapp/VCIClientBridge.kt
+++ b/android/app/src/main/java/io/mosip/residentapp/VCIClientBridge.kt
@@ -152,7 +152,8 @@ object VCIClientBridge {
                                 "txCode" to tokenRequest.txCode,
                                 "clientId" to tokenRequest.clientId,
                                 "redirectUri" to tokenRequest.redirectUri,
-                                "codeVerifier" to tokenRequest.codeVerifier
+                                "codeVerifier" to tokenRequest.codeVerifier,
+                                "dpopProof" to tokenRequest.dpopProof
                         )
 
                 VCIClientCallbackBridge.createTokenResponseDeferred()

--- a/docs/# ADR: DPoP Sender-Constrained Access To.md
+++ b/docs/# ADR: DPoP Sender-Constrained Access To.md
@@ -61,12 +61,12 @@ OID4VCI 1.0 draft-13 mandates DPoP support as the mechanism for sender-constrain
 | DPoP key rotation                          | **Open question** — RFC 9449 is silent on rotation frequency. Policy TBD (wallet reset / periodic / never)                                                                                                                                                                                               |
 | DPoP key vs credential proof key           | Always separate — using the same key for both enables JWT-swapping attacks (read: RFC 9449 §11.5)                                                                                                                                                                                                        |
 | Alg selection — credential endpoint        | Library picks from `clientMetadata.dpop.keys` intersected with AS `dpop_signing_alg_values_supported`                                                                                                                                                                                                    |
-| Alg selection — token endpoint + dpop_jkt  | Wallet pre-selects using `selectCredentialRequestKey()` against AS metadata (same preference order the library uses, so they agree)                                                                                                                                                                      |
+| Alg selection — token endpoint + dpop_jkt  | Library selects alg (from AS discovery) and passes it to wallet via `dpopAlg` in `onRequestTokenResponse`. Library computes `dpop_jkt` and includes it in the auth URL fired via `onRequestAuthCode`. Wallet does not read AS metadata.                                                                  |
 | DPoP config transport                      | Embedded in existing `clientMetadata` JSON as `dpop.keys` — no new native method parameters                                                                                                                                                                                                              |
 | clientMetadata ownership                   | Built in `IssuersService` for both flows; `VciClient.ts` no longer hardcodes it                                                                                                                                                                                                                          |
 | AS nonce                                   | Wallet JS owns: read from token endpoint response, stored as `dpopASNonce` in XState context                                                                                                                                                                                                             |
 | RS nonce                                   | Library owns: extracted from 401 response internally, passed as `signingInput` context to wallet on retry — wallet never stores it                                                                                                                                                                       |
-| Auth code binding                          | Wallet computes `dpop_jkt` from the pre-selected DPoP key and appends to auth URL (read: RFC 9449 §10)                                                                                                                                                                                                   |
+| Auth code binding                          | Library computes `dpop_jkt` from selected DPoP key and includes it in auth URL fired via `onRequestAuthCode` (read: RFC 9449 §10)                                                                                                                                                                        |
 | Pre-auth code flow                         | No `dpop_jkt` — just `DPoP` header on token request                                                                                                                                                                                                                                                      |
 | DPoP attempt — token endpoint              | Always attempt DPoP on the token request (OID4VCI recommends DPoP). `dpop_signing_alg_values_supported` present → use for alg selection. Absent → use wallet's preference order (ES256 first). Check `token_type` in response to confirm whether AS issued a DPoP-bound or Bearer token.                 |
 | Graceful degradation — credential endpoint | Library checks `token_type` from token response. `token_type: "DPoP"` → use DPoP with `ath`. `token_type: "Bearer"` → use Bearer, ignore `clientMetadata.dpop` entirely.                                                                                                                                 |
@@ -203,34 +203,22 @@ If no DPoP keys exist or AS does not support DPoP, `dpop` field is omitted and l
 
 ## Flow Diagrams
 
-### Flow 1 — DPoP Key Setup (both flows)
+### Flow 1 — DPoP Key Setup (wallet side, before calling library)
 
-Runs once at start of each issuance flow. The wallet ensures all DPoP key pairs exist in storage and assembles the full key list for `clientMetadata`. The library will pick the alg.
+Wallet ensures all DPoP key pairs exist in storage and assembles `clientMetadata` with all public keys. Library does all discovery and alg selection internally.
 
 ```mermaid
 flowchart TD
-    A([Start issuance flow]) --> B[Fetch issuer well-known\n/.well-known/openid-credential-issuer]
-    B --> C[Resolve AS endpoint\nfrom authorization_servers field\nor use issuer host if absent]
-    C --> D[Fetch AS well-known\n/.well-known/oauth-authorization-server]
-    D --> G[For each alg in ES256 RS256 EdDSA ES256K\nload DPoP key from storage\ngenerate and store if absent]
+    A([Start issuance flow]) --> G[For each alg in ES256 RS256 EdDSA ES256K\nload DPoP key from storage\ngenerate and store if absent]
     G --> H[Build clientMetadata.dpop.keys\nwith all public key JWKs]
-    H --> I1{dpop_signing_alg_values\n_supported present?}
-    I1 -- Yes --> I2[Select alg from intersection\nof wallet keys and AS-supported algs]
-    I1 -- No --> I3[Use wallet preference order\nES256 first\nfield is optional per RFC9449]
-    I2 --> I{Auth code flow?}
-    I3 --> I
-    I -- Yes --> J[Pre-select alg for dpop_jkt\nusing chosen alg above]
-    I -- No --> K([Proceed to token request with DPoP])
-    J --> L[Compute dpop_jkt = JWK thumbprint\nof pre-selected DPoP key]
-    L --> M([Append dpop_jkt to auth URL\nthen proceed])
+    H --> K([Call library with clientMetadata\nlibrary owns all discovery and alg selection])
 ```
 
 ---
 
 ### Flow 2 — Pre-Authorized Code Flow with DPoP
 
-Token endpoint: wallet JS constructs full DPoP proof.
-Credential endpoint: library constructs proof, wallet only signs.
+Wallet calls the library with `clientMetadata` (which includes all DPoP keys). Library owns all discovery and drives the flow. Wallet responds to events.
 
 ```mermaid
 sequenceDiagram
@@ -240,38 +228,38 @@ sequenceDiagram
     participant AS as Authorization Server
     participant CI as Credential Issuer
 
-    W->>AS: GET /.well-known/oauth-authorization-server
-    AS-->>W: 200 metadata with dpop_signing_alg_values_supported
     W->>W: Ensure all DPoP key pairs in storage
     W->>W: Build clientMetadata with dpop.keys list
-    note over W: pre-authorized_code and optional tx_code already in context
+    W->>L: requestCredentialByOffer(credentialOffer, clientMetadata, callbacks)
 
-    note over W: Token endpoint — wallet owns this request
-    W->>W: Pre-select alg using selectCredentialRequestKey
-    W->>W: Build DPoP proof-A htm=POST htu=token_endpoint no ath no nonce
-    W->>AS: POST /token DPoP=proof-A grant_type=pre-authorized_code pre-authorized_code=X tx_code=Y
+    note over L: Library fetches issuer well-known and AS well-known internally
+    note over L: Library discovers dpop_signing_alg_values_supported and selects alg
+
+    L->>W: onRequestTokenResponse tokenRequest includes dpopAlg and tokenEndpoint
+    note over W: Token endpoint — wallet owns this HTTP request
+    W->>W: Build DPoP proof-A htm=POST htu=tokenEndpoint alg=dpopAlg no ath no nonce
+    W->>AS: POST /token DPoP=proof-A grant_type=pre-authorized_code pre-authorized_code=X
     AS-->>W: 400 error=use_dpop_nonce DPoP-Nonce=nonce-as-1
     note over W: Store nonce-as-1 as dpopASNonce in XState context
     W->>W: Build DPoP proof-B with nonce=nonce-as-1
-    W->>AS: POST /token DPoP=proof-B grant_type=pre-authorized_code pre-authorized_code=X tx_code=Y
+    W->>AS: POST /token DPoP=proof-B grant_type=pre-authorized_code pre-authorized_code=X
     AS-->>W: 200 access_token=T token_type=DPoP DPoP-Nonce=nonce-as-2
     note over W: Validate token_type equals DPoP. Store nonce-as-2 as dpopASNonce.
-    W->>L: sendTokenResponse with access_token=T
+    W->>L: sendTokenResponseFromJS tokenResponse
 
     note over L,CI: Credential endpoint — library owns this request
-    L->>L: Select alg from clientMetadata.dpop.keys vs AS metadata
-    L->>L: Build proof header+payload htm=POST htu=credential_endpoint ath=SHA256(T) jti=uuid iat exp
+    L->>L: Build proof header+payload htm=POST htu=credential_endpoint ath=SHA256(T) jti iat exp
     L->>W: onRequestDPoPSign signingInput=header.payload alg=ES256
     W->>W: RNSecureKeystoreModule.sign alias=DPoP_ES256 input=signingInput
     W->>L: sendDPoPSignatureFromJS signature=sig
-    L->>CI: POST /credential Authorization=DPoP T DPoP=header.payload.sig body has openid4vci-proof+jwt
+    L->>CI: POST /credential Authorization=DPoP T DPoP=header.payload.sig
     CI-->>L: 401 WWW-Authenticate=DPoP error=use_dpop_nonce DPoP-Nonce=nonce-rs-1
-    note over L: Library extracts nonce-rs-1 internally. Wallet never sees this.
-    L->>L: Rebuild proof header+payload with nonce=nonce-rs-1
+    note over L: Library handles RS nonce internally. Wallet never sees this.
+    L->>L: Rebuild proof with nonce=nonce-rs-1
     L->>W: onRequestDPoPSign signingInput=new-header.payload alg=ES256
     W->>W: RNSecureKeystoreModule.sign alias=DPoP_ES256 input=signingInput
     W->>L: sendDPoPSignatureFromJS signature=sig2
-    L->>CI: POST /credential Authorization=DPoP T DPoP=new-header.payload.sig2 body has openid4vci-proof+jwt
+    L->>CI: POST /credential Authorization=DPoP T DPoP=new-header.payload.sig2
     CI-->>L: 200 credential issued
     L-->>W: credential response
 ```
@@ -280,7 +268,7 @@ sequenceDiagram
 
 ### Flow 3 — Authorization Code Flow with DPoP
 
-Wallet pre-selects alg for `dpop_jkt` using the same preference logic the library uses, so they agree on the key.
+Wallet calls the library with `clientMetadata`. Library owns discovery and builds the auth URL including `dpop_jkt` (it knows the alg from AS metadata). Wallet only navigates and responds to events.
 
 ```mermaid
 sequenceDiagram
@@ -291,44 +279,47 @@ sequenceDiagram
     participant AS as Authorization Server
     participant CI as Credential Issuer
 
-    W->>AS: GET /.well-known/oauth-authorization-server
-    AS-->>W: 200 metadata with dpop_signing_alg_values_supported
     W->>W: Ensure all DPoP key pairs in storage
     W->>W: Build clientMetadata with dpop.keys list
-    W->>W: Pre-select alg via selectCredentialRequestKey for dpop_jkt
-    W->>W: Compute dpop_jkt = JWK thumbprint of pre-selected DPoP public key
+    W->>L: requestCredentialByOffer(credentialOffer, clientMetadata, callbacks)
 
-    W->>U: Redirect to AS /authorize with dpop_jkt=jkt and code_challenge=cc
+    note over L: Library fetches issuer well-known and AS well-known internally
+    note over L: Library selects DPoP alg from clientMetadata.dpop.keys vs dpop_signing_alg_values_supported
+    note over L: Library computes dpop_jkt = JWK thumbprint of selected DPoP key
+
+    L->>W: onRequestAuthCode authorizationUrl includes dpop_jkt and code_challenge
+    W->>U: Open browser to authorizationUrl
     note over U,AS: User authenticates. AS records dpop_jkt against the auth code.
     AS-->>W: 302 redirect with code=auth-code
-    note over W: auth-code is bound to the DPoP key via dpop_jkt
+    W->>L: sendAuthCodeFromJS authCode
+    note over L: auth-code is bound to the DPoP key via dpop_jkt
 
-    note over W: Token endpoint — wallet owns this request
-    W->>W: Build DPoP proof-A htm=POST htu=token_endpoint no ath no nonce
-    W->>AS: POST /token DPoP=proof-A grant_type=authorization_code code=auth-code code_verifier=cv redirect_uri=ru
+    L->>W: onRequestTokenResponse tokenRequest includes dpopAlg and tokenEndpoint
+    note over W: Token endpoint — wallet owns this HTTP request
+    W->>W: Build DPoP proof-A htm=POST htu=tokenEndpoint alg=dpopAlg no ath no nonce
+    W->>AS: POST /token DPoP=proof-A grant_type=authorization_code code=auth-code code_verifier=cv
     AS-->>W: 400 error=use_dpop_nonce DPoP-Nonce=nonce-as-1
     note over W: Store nonce-as-1 as dpopASNonce
     W->>W: Build DPoP proof-B with nonce=nonce-as-1
-    W->>AS: POST /token DPoP=proof-B grant_type=authorization_code code=auth-code code_verifier=cv redirect_uri=ru
+    W->>AS: POST /token DPoP=proof-B grant_type=authorization_code code=auth-code code_verifier=cv
     note over AS: AS verifies DPoP public key in proof-B matches dpop_jkt bound to auth-code
     AS-->>W: 200 access_token=T token_type=DPoP DPoP-Nonce=nonce-as-2
     note over W: Validate token_type equals DPoP. Store nonce-as-2 as dpopASNonce.
-    W->>L: sendTokenResponse with access_token=T
+    W->>L: sendTokenResponseFromJS tokenResponse
 
     note over L,CI: Credential endpoint — library owns this request
-    L->>L: Select alg from clientMetadata.dpop.keys vs AS metadata
-    L->>L: Build proof header+payload htm=POST htu=credential_endpoint ath=SHA256(T) jti=uuid iat exp
+    L->>L: Build proof header+payload htm=POST htu=credential_endpoint ath=SHA256(T) jti iat exp
     L->>W: onRequestDPoPSign signingInput=header.payload alg=ES256
     W->>W: RNSecureKeystoreModule.sign alias=DPoP_ES256 input=signingInput
     W->>L: sendDPoPSignatureFromJS signature=sig
-    L->>CI: POST /credential Authorization=DPoP T DPoP=header.payload.sig body has openid4vci-proof+jwt
+    L->>CI: POST /credential Authorization=DPoP T DPoP=header.payload.sig
     CI-->>L: 401 WWW-Authenticate=DPoP error=use_dpop_nonce DPoP-Nonce=nonce-rs-1
     note over L: Library handles RS nonce internally
     L->>L: Rebuild proof with nonce=nonce-rs-1
     L->>W: onRequestDPoPSign signingInput=new-header.payload alg=ES256
     W->>W: RNSecureKeystoreModule.sign alias=DPoP_ES256 input=signingInput
     W->>L: sendDPoPSignatureFromJS signature=sig2
-    L->>CI: POST /credential Authorization=DPoP T DPoP=new-header.payload.sig2 body has openid4vci-proof+jwt
+    L->>CI: POST /credential Authorization=DPoP T DPoP=new-header.payload.sig2
     note over CI: CI verifies cnf.jkt in access token T matches DPoP public key in proof
     CI-->>L: 200 credential issued
     L-->>W: credential response
@@ -440,7 +431,7 @@ stateDiagram-v2
         generateMissing --> [*] : dpopKeys map in context with all public JWKs
     }
 
-    ensuringDPoPKeys --> authRedirect : auth code flow\ndpop_jkt appended using pre-selected key
+    ensuringDPoPKeys --> authRedirect : auth code flow\nlibrary includes dpop_jkt in auth URL
     ensuringDPoPKeys --> tokenRequest : pre-auth flow
 
     authRedirect --> waitingForAuthCode

--- a/docs/# ADR: DPoP Sender-Constrained Access To.md
+++ b/docs/# ADR: DPoP Sender-Constrained Access To.md
@@ -13,39 +13,41 @@
 
 The wallet currently exchanges authorization grants for Bearer access tokens and presents them to the credential endpoint as `Authorization: Bearer <token>`. Bearer tokens are not bound to any client identity — anyone who intercepts or exfiltrates a token can replay it against any resource server.
 
-RFC 9449 (DPoP — Demonstrating Proof of Possession) adds sender-constraint to OAuth 2.0 access tokens by cryptographically binding each token to a client-controlled key pair. The wallet must prove possession of the private key on every request that uses the token. A stolen token is therefore useless without the corresponding private key.
+RFC 9449 (DPoP — Demonstrating Proof of Possession) adds sender-constraint to OAuth 2.0 access tokens by cryptographically binding each token to a client-controlled key pair. The client must prove possession of the private key on every request that uses the token. A stolen token is therefore useless without the corresponding private key.
 
 OID4VCI 1.0 draft-13 mandates DPoP support as the mechanism for sender-constrained access tokens at both the authorization server (token endpoint) and the credential issuer (credential endpoint).
 
 ### Current gaps
 
-- `sendTokenRequest` (JS) sends a plain `fetch()` with no `DPoP` header.
+- The token request is performed by the wallet (the `getTokenResponse` / `TokenResponseCallback`), which sends a plain POST with no `DPoP` header.
 - The credential endpoint is called by the native `VCIClient` library with `Authorization: Bearer`.
-- No DPoP key management, proof construction, or nonce handling exists anywhere.
+- No DPoP key management, proof construction, signing, or nonce handling exists anywhere.
 
 ---
 
 ## Decision Drivers
 
 - **Security:** Prevent access token replay after exfiltration (BREACH, Heartbleed, XSS-class attacks as cited in RFC 9449 §2).
-- **Interoperability:** Be compatible with AS and RS that enforce `dpop_bound_access_tokens: true`. Support all key types the wallet already has.
+- **Interoperability:** Be compatible with AS and RS that enforce `dpop_bound_access_tokens: true`. Support the algorithms the AS advertises.
 - **Spec compliance:** OID4VCI 1.0 d13 requires DPoP for sender-constrained token flows.
-- **Minimal disruption:** The token request is already JS-owned. The credential request is native — extend the bridge without forking VCIClient internals.
-- **Separation of concerns:** The library knows HTTP context (htm, htu, nonce from RS). The wallet knows keys and signing. Each does what it knows.
+- **Single owner for DPoP:** DPoP is a protocol concern — proof structure, nonce handling, retries, key binding, and signing are tightly coupled. Splitting them across the wallet/library boundary (the original "wallet signs via closure" design) creates two state machines that must stay in lockstep. Keeping the **entire** DPoP mechanism inside the library removes that coupling.
+- **Minimal wallet surface:** The wallet should not have to learn DPoP. It owns the token HTTP request only because that request is wallet-side today; everything DPoP about it should arrive pre-built.
 
 ---
 
 ## Plan
 
-### Split responsibility: library constructs proofs, wallet signs ✓
+### Library owns DPoP end-to-end; wallet only carries the prepared proof ✓
 
-**Token endpoint (JS-owned):** Wallet constructs the full DPoP proof and adds the `DPoP` header in `sendTokenRequest`. AS nonce is managed entirely in JS.
+This supersedes the earlier "library constructs, wallet signs via `signDPoP` closure" proposal. Feedback on that design: we do **not** want a signing closure handed to the wallet, and we do not want the wallet to construct or sign DPoP proofs at all. The library prepares **and** signs every DPoP proof.
 
-**Credential endpoint (library-owned):** The VCIClient library constructs DPoP proofs internally — it already knows `htm`, `htu`, `accessToken`, and any RS-provided nonce from 401 responses. The library fires an `onRequestDPoPSign` callback with the `signingInput` (the `header.payload` bytes to sign) and which `alg` it chose. The wallet signs using the matching DPoP key alias and returns the raw signature. The library assembles the final JWT and injects the headers.
+**DPoP keys (library-owned, ephemeral per flow):** The `VCIClient` library generates a fresh DPoP key pair **in memory at the start of each issuance flow**, uses it for every proof in that flow, and discards it when the flow ends. Nothing is persisted to a keystore. The wallet never holds, passes, or signs with DPoP keys. The same in-memory key signs all three bindings within a flow — `dpop_jkt` in the auth URL, the token-endpoint proof, and the credential-endpoint proof — because the AS and issuer verify those against each other (a per-request key would break the flow).
 
-**Key negotiation:** The wallet passes all available DPoP public keys (one per supported alg) inside `clientMetadata.dpop.keys`. The library intersects this with `dpop_signing_alg_values_supported` from AS metadata and picks the best match. The wallet never needs to read AS metadata for DPoP key selection.
+**Credential endpoint (library-owned HTTP):** The library already owns this request. It builds, signs, sends, and handles the RS nonce retry entirely internally. The wallet is not involved at any point — no callback, no closure.
 
-**Chosen.** Clean separation: library owns protocol (proof structure, RS nonce, retry), wallet owns keys (generation, storage, signing). No new native method parameters — all DPoP config travels inside the existing `clientMetadata` JSON string.
+**Token endpoint (wallet-owned HTTP):** The library builds and signs the token-endpoint DPoP proof and hands the finished proof string to the wallet as a **new field on `TokenRequest`** (`dpopProof`). The wallet attaches it as the `DPoP` header on the POST it already makes. On an AS `use_dpop_nonce` challenge, the wallet calls a small library method, passing the AS-supplied nonce, to obtain a fresh signed proof and retries. The wallet never reads AS metadata, never picks an alg, never touches a key.
+
+**Chosen.** One owner for the whole DPoP mechanism. The wallet's only DPoP responsibility is to copy a string into a header and, on a nonce challenge, ask the library for a new string.
 
 ---
 
@@ -53,31 +55,31 @@ OID4VCI 1.0 draft-13 mandates DPoP support as the mechanism for sender-constrain
 
 ### Key design
 
-| Concern                                    | Decision                                                                                                                                                                                                                                                                                                 |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| DPoP key algorithms                        | One persistent key pair per supported alg: `DPoP_ES256`, `DPoP_RS256`, `DPoP_EdDSA`, `DPoP_ES256K`                                                                                                                                                                                                       |
-| DPoP key storage                           | `RNSecureKeystoreModule` generic key storage, one alias per alg                                                                                                                                                                                                                                          |
-| DPoP key generation                        | Per-alg: generated once on first use, loaded from alias on subsequent flows                                                                                                                                                                                                                              |
-| DPoP key rotation                          | **Open question** — RFC 9449 is silent on rotation frequency. Policy TBD (wallet reset / periodic / never)                                                                                                                                                                                               |
-| DPoP key vs credential proof key           | Always separate — using the same key for both enables JWT-swapping attacks (read: RFC 9449 §11.5)                                                                                                                                                                                                        |
-| Alg selection — credential endpoint        | Library picks from `clientMetadata.dpop.keys` intersected with AS `dpop_signing_alg_values_supported`                                                                                                                                                                                                    |
-| Alg selection — token endpoint + dpop_jkt  | Library selects alg (from AS discovery) and passes it to wallet via `dpopAlg` in `onRequestTokenResponse`. Library computes `dpop_jkt` and includes it in the auth URL fired via `onRequestAuthCode`. Wallet does not read AS metadata.                                                                  |
-| DPoP config transport                      | Embedded in existing `clientMetadata` JSON as `dpop.keys` — no new native method parameters                                                                                                                                                                                                              |
-| clientMetadata ownership                   | Built in `IssuersService` for both flows; `VciClient.ts` no longer hardcodes it                                                                                                                                                                                                                          |
-| AS nonce                                   | Wallet JS owns: read from token endpoint response, stored as `dpopASNonce` in XState context                                                                                                                                                                                                             |
-| RS nonce                                   | Library owns: extracted from 401 response internally, passed as `signingInput` context to wallet on retry — wallet never stores it                                                                                                                                                                       |
-| Auth code binding                          | Library computes `dpop_jkt` from selected DPoP key and includes it in auth URL fired via `onRequestAuthCode` (read: RFC 9449 §10)                                                                                                                                                                        |
-| Pre-auth code flow                         | No `dpop_jkt` — just `DPoP` header on token request                                                                                                                                                                                                                                                      |
-| DPoP attempt — token endpoint              | Always attempt DPoP on the token request (OID4VCI recommends DPoP). `dpop_signing_alg_values_supported` present → use for alg selection. Absent → use wallet's preference order (ES256 first). Check `token_type` in response to confirm whether AS issued a DPoP-bound or Bearer token.                 |
-| Graceful degradation — credential endpoint | Library checks `token_type` from token response. `token_type: "DPoP"` → use DPoP with `ath`. `token_type: "Bearer"` → use Bearer, ignore `clientMetadata.dpop` entirely.                                                                                                                                 |
-| RS Bearer-only 401 fallback                | If credential endpoint returns 401 with `WWW-Authenticate: Bearer` only (no DPoP challenge) → spec §7.2 permits retrying with Bearer as best-effort. Not guaranteed — RS could still reject. If `WWW-Authenticate: DPoP` is present (with or without Bearer) → never downgrade, handle DPoP errors only. |
+| Concern                                    | Decision                                                                                                                                                                                                                                                                                                                                                          |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| DPoP key ownership                         | **Library.** Generated, held, and used for signing entirely inside `VCIClient`. The wallet never sees the private key and never signs.                                                                                                                                                                                                                            |
+| DPoP key lifetime                          | **Ephemeral, in memory, one key pair per issuance flow.** Generated at flow start, reused for every proof in the flow, discarded at flow end. Nothing is written to a keystore — no persistence at rest.                                                                                                                                                          |
+| DPoP key reuse within a flow               | The **same** in-memory key signs `dpop_jkt` (auth URL), the token-endpoint proof, and the credential-endpoint proof. A per-request key would break the AS/issuer cross-checks (`dpop_jkt` ↔ token proof ↔ `cnf.jkt`).                                                                                                                                             |
+| DPoP key rotation                          | Not applicable — a fresh key per flow is inherent rotation. No rotation policy needed.                                                                                                                                                                                                                                                                            |
+| DPoP key vs credential proof key           | Always separate — using the same key for both enables JWT-swapping attacks (read: RFC 9449 §11.5). The credential proof key remains wallet-owned and is delivered via the existing `getProofs` callback, unchanged.                                                                                                                                               |
+| Alg selection (both endpoints + dpop_jkt)  | Library selects the alg by intersecting its supported algs with the AS `dpop_signing_alg_values_supported` (discovered internally), then generates the ephemeral key for that alg. Falls back to its preference order (ES256 first) when the AS omits the list. Prefer EC/EdDSA — generating an RSA key pair per flow is expensive; treat RS256 as a last resort. |
+| Proof construction & signing               | **Library, for every proof** — token endpoint and credential endpoint. Wallet performs no construction and no signing.                                                                                                                                                                                                                                            |
+| Transport of token-endpoint proof          | New `dpopProof: String?` field on the existing `TokenRequest` passed to the `getTokenResponse` callback. No new top-level method parameters; no `clientMetadata` changes.                                                                                                                                                                                         |
+| AS nonce retry (token endpoint)            | Wallet reads `DPoP-Nonce` from the AS `400 use_dpop_nonce` response and calls a new library method `generateTokenDPoPProof(dpopNonce:)` to get a fresh signed proof, then retries the POST. Wallet relays only the nonce — the library reuses the active flow's endpoint, alg, and ephemeral key.                                                                 |
+| RS nonce (credential endpoint)             | Library owns it fully: extracts `DPoP-Nonce` from the 401, rebuilds and re-signs internally, retries. The wallet never sees the RS nonce.                                                                                                                                                                                                                         |
+| Auth code binding (`dpop_jkt`)             | Library computes `dpop_jkt` from its own DPoP key and includes it in the authorization URL it builds (read: RFC 9449 §10). Wallet only opens the URL.                                                                                                                                                                                                             |
+| Pre-auth code flow                         | No `dpop_jkt` — just the `DPoP` header on the token request, supplied as `tokenRequest.dpopProof`.                                                                                                                                                                                                                                                                |
+| DPoP attempt — token endpoint              | Library always attempts DPoP (OID4VCI recommends it). The wallet's POST simply carries whatever `dpopProof` the library supplied. The AS `token_type` in the response is the actual outcome signal (DPoP vs Bearer).                                                                                                                                              |
+| Graceful degradation — credential endpoint | Library checks `token_type` from the token response. `token_type: "DPoP"` → use DPoP with `ath`. `token_type: "Bearer"` → use Bearer, skip DPoP entirely. Decided and acted on internally.                                                                                                                                                                        |
+| RS Bearer-only 401 fallback                | If the credential endpoint returns 401 with `WWW-Authenticate: Bearer` only (no DPoP challenge) → §7.2 permits a best-effort Bearer retry. If `WWW-Authenticate: DPoP` is present → never downgrade; handle DPoP errors only. All internal to the library.                                                                                                        |
 
 ### Open questions
 
-| #    | Question                                                                                                                                                                                                                                                                               | Impact                    |
-| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| OQ-1 | **DPoP key rotation frequency** — RFC 9449 is silent. Options: wallet reset, time-based (e.g. 90 days), never.                                                                                                                                                                         | Key management complexity |
-| OQ-2 | **AS rejects DPoP header despite OID4VCI recommendation** — wallet sends DPoP, AS returns error (not `use_dpop_nonce`). Should wallet retry as Bearer or hard-fail? Policy call: retrying as Bearer degrades security; hard-failing is safer but breaks interop with non-compliant AS. | Degradation policy        |
+| #    | Question                                                                                                                                                                                                                                                                                                                                           | Impact             |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| OQ-1 | **AS rejects the DPoP header despite the OID4VCI recommendation** — library sends DPoP, AS returns an error that is not `use_dpop_nonce`. Should the library retry as Bearer or hard-fail? Retrying degrades security; hard-failing breaks non-compliant AS.                                                                                       | Degradation policy |
+| OQ-2 | **In-memory crypto in the library.** `VCIClient` has not previously held keys or signed anything (all signing is delegated to the wallet via `getProofs`). Owning ephemeral DPoP keys requires new in-memory keygen + signing code in both the Swift and Kotlin libraries — but **no** secure persistent storage, since keys never outlive a flow. |
+| OQ-3 | **Deferred / resumable issuance.** An in-memory key cannot survive an app restart or a long-deferred credential poll. If deferred issuance (or resuming an interrupted flow) is ever required, that flow would need either a persisted key or a fresh authorization. Out of scope while flows are synchronous.                                     |
 
 ---
 
@@ -103,163 +105,116 @@ Payload:
 }
 ```
 
-`ath` is absent on the token endpoint request. Mandatory on the credential endpoint request.
+`ath` is absent on the token endpoint request. Mandatory on the credential endpoint request. The library builds and signs both forms.
 
 ---
 
 ## Library API Changes
 
-### `ClientMetadata` struct extension
+All DPoP construction and signing moves into the library. The wallet-facing surface is two small additions; nothing about `ClientMetadata` or the existing callbacks changes.
 
-The VCIClient library's `ClientMetadata` gains an optional `dpop` field. No existing fields change; no new method parameters are added anywhere.
+### `ClientMetadata` — unchanged
 
-```swift
-// VCIClient library — ClientMetadata
-struct DPoPKeyEntry: Codable {
-  let alg: String           // "ES256" | "RS256" | "EdDSA" | "ES256K"
-  let publicKeyJWK: AnyCodable
-}
-
-struct DPoPConfig: Codable {
-  let keys: [DPoPKeyEntry]  // all DPoP public keys the wallet holds
-}
-
-struct ClientMetadata: Codable {
-  let clientId: String
-  let redirectUri: String
-  let dpop: DPoPConfig?     // nil → library uses Bearer only
-}
-```
-
-Equivalent TypeScript type used by `IssuersService` when building `clientMetadata`:
-
-```typescript
-type ClientMetadata = {
-  clientId: string;
-  redirectUri: string;
-  dpop?: {
-    keys: Array<{alg: string; publicKeyJWK: object}>;
-  };
-};
-```
-
-### `fetchCredentialsUsingCredentialOffer` / `fetchCredentialsFromTrustedIssuer` — new `signDPoP` closure
-
-The library gains one new optional closure parameter. All existing parameters are unchanged.
+DPoP keys are no longer passed by the wallet, so `ClientMetadata` keeps its current shape:
 
 ```swift
-// Added to both fetch methods — nil when dpop is absent from ClientMetadata
-signDPoP: ((_ signingInput: String, _ alg: String) async throws -> String)?
-```
-
-The library calls this closure each time it needs a DPoP proof signed. It constructs the JWT header and payload internally, serialises to `base64url(header).base64url(payload)`, and passes that as `signingInput`. The wallet returns `base64url(signature)`. The library appends the signature to form the complete JWT.
-
-### `onRequestDPoPSign` event / `sendDPoPSignatureFromJS` receiver
-
-Mirrors the existing `onRequestProof` / `sendProofFromJS` pattern exactly.
-
-```
-Native → JS event: onRequestDPoPSign
-  { "signingInput": "eyJ...", "alg": "ES256" }
-
-JS → Native receiver: sendDPoPSignatureFromJS
-  "MEYCIQDnp3..."   ← base64url(ES256 signature over signingInput bytes)
-```
-
-### `clientMetadata` on the wire
-
-```json
-{
-  "clientId": "wallet",
-  "redirectUri": "io.mosip.residentapp.inji://oauthredirect",
-  "dpop": {
-    "keys": [
-      {
-        "alg": "ES256",
-        "publicKeyJWK": {"kty": "EC", "crv": "P-256", "x": "...", "y": "..."}
-      },
-      {"alg": "RS256", "publicKeyJWK": {"kty": "RSA", "n": "...", "e": "AQAB"}},
-      {
-        "alg": "EdDSA",
-        "publicKeyJWK": {"kty": "OKP", "crv": "Ed25519", "x": "..."}
-      },
-      {
-        "alg": "ES256K",
-        "publicKeyJWK": {
-          "kty": "EC",
-          "crv": "secp256k1",
-          "x": "...",
-          "y": "..."
-        }
-      }
-    ]
-  }
+public struct ClientMetadata: Codable {
+    public let clientId: String
+    public let redirectUri: String
 }
 ```
 
-If no DPoP keys exist or AS does not support DPoP, `dpop` field is omitted and library falls back to Bearer.
+### `TokenRequest` — new `dpopProof` field
+
+The library builds and signs the token-endpoint proof and attaches it to the `TokenRequest` it already passes to the `getTokenResponse` callback. This is the "new param in the token request callback."
+
+```swift
+public struct TokenRequest {
+    public let grantType: GrantType
+    public let tokenEndpoint: String
+    public let authCode: String?
+    public let preAuthCode: String?
+    public let txCode: String?
+    public let clientId: String?
+    public let redirectUri: String?
+    public let codeVerifier: String?
+    public let dpopProof: String?   // NEW — signed dpop+jwt for the token POST; nil ⇒ Bearer
+}
+```
+
+The wallet's `getTokenResponse` implementation copies `tokenRequest.dpopProof` into the `DPoP` request header (when non-nil) and otherwise behaves exactly as today.
+
+### `VCIClient.generateTokenDPoPProof(dpopNonce:)` — new method for the AS nonce retry
+
+When the AS answers the first token POST with `400 use_dpop_nonce` + a `DPoP-Nonce` header, the wallet asks the library for a fresh proof bound to that nonce, then retries. The library rebuilds and re-signs internally with its own key.
+
+```swift
+// New public method on VCIClient — used only on a use_dpop_nonce challenge
+public func generateTokenDPoPProof(
+    dpopNonce: String
+) async throws -> String
+```
+
+The wallet passes only the nonce. The library already holds the flow's `tokenEndpoint` (the `htu`), selected alg, and ephemeral key from when it built the first proof, so they are not passed back in. **Precondition:** valid only during an active flow — if the ephemeral key is gone (flow ended / app restarted), the call throws rather than mint a new key, since a new key would break the `dpop_jkt` ↔ token-proof ↔ `cnf.jkt` chain.
+
+This is a wallet→library call (the wallet already holds the `VCIClient` instance). It is **not** a closure handed to the wallet, and it never exposes signing material.
+
+### Credential endpoint — no wallet-facing change
+
+The credential request is library-owned HTTP. The library constructs, signs, sends, handles the `use_dpop_nonce` 401, and retries entirely internally. There is **no** `signDPoP` closure and **no** `onRequestDPoPSign` / `sendDPoPSignatureFromJS` bridge event — these are removed from the design.
 
 ---
 
 ## Flow Diagrams
 
-### Flow 1 — DPoP Key Setup (wallet side, before calling library)
+### Flow 1 — DPoP Key Setup (library internal, ephemeral)
 
-Wallet ensures all DPoP key pairs exist in storage and assembles `clientMetadata` with all public keys. Library does all discovery and alg selection internally.
+At the start of each flow the library generates a fresh in-memory DPoP key pair for the selected alg. No persistence, no keystore. The wallet does nothing here.
 
 ```mermaid
 flowchart TD
-    A([Start issuance flow]) --> G[For each alg in ES256 RS256 EdDSA ES256K\nload DPoP key from storage\ngenerate and store if absent]
-    G --> H[Build clientMetadata.dpop.keys\nwith all public key JWKs]
-    H --> K([Call library with clientMetadata\nlibrary owns all discovery and alg selection])
+    A([Library begins a flow that needs DPoP]) --> B[Discover dpop_signing_alg_values_supported from AS]
+    B --> C[Select alg: intersect supported algs with AS list\nfall back to ES256-first preference if AS omits it]
+    C --> D[Generate a fresh ephemeral key pair for the selected alg\nin memory — prefer EC/EdDSA, RS256 last resort]
+    D --> E([Key held in memory for this flow only\nlibrary signs all proofs internally, discards at flow end])
 ```
 
 ---
 
 ### Flow 2 — Pre-Authorized Code Flow with DPoP
 
-Wallet calls the library with `clientMetadata` (which includes all DPoP keys). Library owns all discovery and drives the flow. Wallet responds to events.
+The wallet calls the library and only relays HTTP for the token endpoint. The library owns every DPoP concern.
 
 ```mermaid
 sequenceDiagram
     autonumber
-    participant W as Wallet JS
+    participant W as Wallet
     participant L as VCIClient Library
     participant AS as Authorization Server
     participant CI as Credential Issuer
 
-    W->>W: Ensure all DPoP key pairs in storage
-    W->>W: Build clientMetadata with dpop.keys list
-    W->>L: requestCredentialByOffer(credentialOffer, clientMetadata, callbacks)
+    W->>L: fetchCredentialsUsingCredentialOffer(credentialOffer, clientMetadata, callbacks)
 
-    note over L: Library fetches issuer well-known and AS well-known internally
-    note over L: Library discovers dpop_signing_alg_values_supported and selects alg
+    note over L: Library fetches issuer + AS well-known internally
+    note over L: Library selects DPoP alg and ensures its DPoP key pair (Flow 1)
+    note over L: Library builds + signs token proof-A (htm=POST, htu=tokenEndpoint, no ath, no nonce)
 
-    L->>W: onRequestTokenResponse tokenRequest includes dpopAlg and tokenEndpoint
-    note over W: Token endpoint — wallet owns this HTTP request
-    W->>W: Build DPoP proof-A htm=POST htu=tokenEndpoint alg=dpopAlg no ath no nonce
-    W->>AS: POST /token DPoP=proof-A grant_type=pre-authorized_code pre-authorized_code=X
-    AS-->>W: 400 error=use_dpop_nonce DPoP-Nonce=nonce-as-1
-    note over W: Store nonce-as-1 as dpopASNonce in XState context
-    W->>W: Build DPoP proof-B with nonce=nonce-as-1
-    W->>AS: POST /token DPoP=proof-B grant_type=pre-authorized_code pre-authorized_code=X
-    AS-->>W: 200 access_token=T token_type=DPoP DPoP-Nonce=nonce-as-2
-    note over W: Validate token_type equals DPoP. Store nonce-as-2 as dpopASNonce.
-    W->>L: sendTokenResponseFromJS tokenResponse
+    L->>W: getTokenResponse(tokenRequest) — tokenRequest.dpopProof = proof-A
+    note over W: Token endpoint — wallet owns this HTTP request only
+    W->>AS: POST /token  DPoP=proof-A  grant_type=pre-authorized_code  pre-authorized_code=X
+    AS-->>W: 400 error=use_dpop_nonce  DPoP-Nonce=nonce-as-1
+    W->>L: generateTokenDPoPProof(dpopNonce=nonce-as-1)
+    L-->>W: proof-B (signed, includes nonce=nonce-as-1)
+    W->>AS: POST /token  DPoP=proof-B  grant_type=pre-authorized_code  pre-authorized_code=X
+    AS-->>W: 200 access_token=T  token_type=DPoP
+    W-->>L: return TokenResponse (access_token=T, token_type=DPoP)
 
-    note over L,CI: Credential endpoint — library owns this request
-    L->>L: Build proof header+payload htm=POST htu=credential_endpoint ath=SHA256(T) jti iat exp
-    L->>W: onRequestDPoPSign signingInput=header.payload alg=ES256
-    W->>W: RNSecureKeystoreModule.sign alias=DPoP_ES256 input=signingInput
-    W->>L: sendDPoPSignatureFromJS signature=sig
-    L->>CI: POST /credential Authorization=DPoP T DPoP=header.payload.sig
-    CI-->>L: 401 WWW-Authenticate=DPoP error=use_dpop_nonce DPoP-Nonce=nonce-rs-1
-    note over L: Library handles RS nonce internally. Wallet never sees this.
-    L->>L: Rebuild proof with nonce=nonce-rs-1
-    L->>W: onRequestDPoPSign signingInput=new-header.payload alg=ES256
-    W->>W: RNSecureKeystoreModule.sign alias=DPoP_ES256 input=signingInput
-    W->>L: sendDPoPSignatureFromJS signature=sig2
-    L->>CI: POST /credential Authorization=DPoP T DPoP=new-header.payload.sig2
+    note over L,CI: Credential endpoint — library owns the request AND the DPoP proof end-to-end
+    note over L: token_type==DPoP → build + sign proof (ath=SHA256(T), jti, iat, exp)
+    L->>CI: POST /credential  Authorization=DPoP T  DPoP=proof
+    CI-->>L: 401 WWW-Authenticate=DPoP  error=use_dpop_nonce  DPoP-Nonce=nonce-rs-1
+    note over L: Library stores RS nonce, rebuilds + re-signs internally. Wallet never sees this.
+    L->>CI: POST /credential  Authorization=DPoP T  DPoP=proof'(nonce=nonce-rs-1)
     CI-->>L: 200 credential issued
     L-->>W: credential response
 ```
@@ -268,110 +223,93 @@ sequenceDiagram
 
 ### Flow 3 — Authorization Code Flow with DPoP
 
-Wallet calls the library with `clientMetadata`. Library owns discovery and builds the auth URL including `dpop_jkt` (it knows the alg from AS metadata). Wallet only navigates and responds to events.
+The library computes `dpop_jkt` from its own key and bakes it into the authorization URL. The wallet only opens the browser and relays the token POST.
 
 ```mermaid
 sequenceDiagram
     autonumber
     participant U as User Browser
-    participant W as Wallet JS
+    participant W as Wallet
     participant L as VCIClient Library
     participant AS as Authorization Server
     participant CI as Credential Issuer
 
-    W->>W: Ensure all DPoP key pairs in storage
-    W->>W: Build clientMetadata with dpop.keys list
-    W->>L: requestCredentialByOffer(credentialOffer, clientMetadata, callbacks)
+    W->>L: fetchCredentialsUsingCredentialOffer(credentialOffer, clientMetadata, callbacks)
 
-    note over L: Library fetches issuer well-known and AS well-known internally
-    note over L: Library selects DPoP alg from clientMetadata.dpop.keys vs dpop_signing_alg_values_supported
-    note over L: Library computes dpop_jkt = JWK thumbprint of selected DPoP key
+    note over L: Library fetches well-knowns, selects DPoP alg, ensures DPoP key (Flow 1)
+    note over L: Library computes dpop_jkt = JWK thumbprint of its DPoP key
 
-    L->>W: onRequestAuthCode authorizationUrl includes dpop_jkt and code_challenge
+    L->>W: authorize(authorizationUrl) — URL includes dpop_jkt and code_challenge
     W->>U: Open browser to authorizationUrl
     note over U,AS: User authenticates. AS records dpop_jkt against the auth code.
     AS-->>W: 302 redirect with code=auth-code
-    W->>L: sendAuthCodeFromJS authCode
-    note over L: auth-code is bound to the DPoP key via dpop_jkt
+    W-->>L: return auth-code
+    note over L: auth-code is bound to the library's DPoP key via dpop_jkt
+    note over L: Library builds + signs token proof-A (no nonce)
 
-    L->>W: onRequestTokenResponse tokenRequest includes dpopAlg and tokenEndpoint
-    note over W: Token endpoint — wallet owns this HTTP request
-    W->>W: Build DPoP proof-A htm=POST htu=tokenEndpoint alg=dpopAlg no ath no nonce
-    W->>AS: POST /token DPoP=proof-A grant_type=authorization_code code=auth-code code_verifier=cv
-    AS-->>W: 400 error=use_dpop_nonce DPoP-Nonce=nonce-as-1
-    note over W: Store nonce-as-1 as dpopASNonce
-    W->>W: Build DPoP proof-B with nonce=nonce-as-1
-    W->>AS: POST /token DPoP=proof-B grant_type=authorization_code code=auth-code code_verifier=cv
-    note over AS: AS verifies DPoP public key in proof-B matches dpop_jkt bound to auth-code
-    AS-->>W: 200 access_token=T token_type=DPoP DPoP-Nonce=nonce-as-2
-    note over W: Validate token_type equals DPoP. Store nonce-as-2 as dpopASNonce.
-    W->>L: sendTokenResponseFromJS tokenResponse
+    L->>W: getTokenResponse(tokenRequest) — tokenRequest.dpopProof = proof-A
+    W->>AS: POST /token  DPoP=proof-A  grant_type=authorization_code  code=auth-code  code_verifier=cv
+    AS-->>W: 400 error=use_dpop_nonce  DPoP-Nonce=nonce-as-1
+    W->>L: generateTokenDPoPProof(dpopNonce=nonce-as-1)
+    L-->>W: proof-B (signed, includes nonce=nonce-as-1)
+    W->>AS: POST /token  DPoP=proof-B  grant_type=authorization_code  code=auth-code  code_verifier=cv
+    note over AS: AS verifies the DPoP public key in proof-B matches dpop_jkt bound to auth-code
+    AS-->>W: 200 access_token=T  token_type=DPoP
+    W-->>L: return TokenResponse (access_token=T, token_type=DPoP)
 
-    note over L,CI: Credential endpoint — library owns this request
-    L->>L: Build proof header+payload htm=POST htu=credential_endpoint ath=SHA256(T) jti iat exp
-    L->>W: onRequestDPoPSign signingInput=header.payload alg=ES256
-    W->>W: RNSecureKeystoreModule.sign alias=DPoP_ES256 input=signingInput
-    W->>L: sendDPoPSignatureFromJS signature=sig
-    L->>CI: POST /credential Authorization=DPoP T DPoP=header.payload.sig
-    CI-->>L: 401 WWW-Authenticate=DPoP error=use_dpop_nonce DPoP-Nonce=nonce-rs-1
-    note over L: Library handles RS nonce internally
-    L->>L: Rebuild proof with nonce=nonce-rs-1
-    L->>W: onRequestDPoPSign signingInput=new-header.payload alg=ES256
-    W->>W: RNSecureKeystoreModule.sign alias=DPoP_ES256 input=signingInput
-    W->>L: sendDPoPSignatureFromJS signature=sig2
-    L->>CI: POST /credential Authorization=DPoP T DPoP=new-header.payload.sig2
-    note over CI: CI verifies cnf.jkt in access token T matches DPoP public key in proof
-    CI-->>L: 200 credential issued
+    note over L,CI: Credential endpoint — library owns request AND DPoP proof end-to-end
+    note over L: build + sign proof (ath=SHA256(T)) — handle RS use_dpop_nonce 401 internally
+    L->>CI: POST /credential  Authorization=DPoP T  DPoP=proof
+    CI-->>L: 200 credential issued (cnf.jkt in T matches the DPoP key)
     L-->>W: credential response
 ```
 
 ---
 
-### Flow 4 — Token Endpoint DPoP Proof Construction (Wallet JS)
+### Flow 4 — Token Endpoint DPoP Proof Construction (Library)
 
-The wallet constructs the full proof for the token endpoint because it owns that HTTP request.
+The library constructs **and signs** the token-endpoint proof. The wallet receives a finished string on `TokenRequest`.
 
 ```mermaid
 flowchart TD
-    A([constructDPoPProof called]) --> B[Generate UUID v4 as jti]
-    B --> C[Normalize URL\nstrip query string and fragment as htu]
-    C --> D{dpopASNonce\nin XState context?}
-    D -- Yes --> E[Include nonce claim]
+    A([Library about to fire getTokenResponse]) --> B[Generate UUID v4 as jti]
+    B --> C[Normalize tokenEndpoint\nstrip query string and fragment as htu]
+    C --> D{AS nonce known?\nfirst attempt: no}
     D -- No --> F[Omit nonce claim]
-    E --> G[Build JWT payload\njti htm htu iat exp=iat+60 nonce if present\nno ath at token endpoint]
+    D -- Yes --> E[Include nonce claim\nused by generateTokenDPoPProof on retry]
+    E --> G[Build payload\njti htm=POST htu iat exp=iat+60 nonce?\nno ath at token endpoint]
     F --> G
-    G --> H[Build JWT header\ntyp=dpop+jwt alg=selectedAlg\njwk=selected DPoP public key JWK\nno kid no x5c]
-    H --> I[Sign with RNSecureKeystoreModule\nusing DPoP_selectedAlg alias]
-    I --> J([Return signed dpop+jwt\nadded as DPoP header on token request])
+    G --> H[Build header\ntyp=dpop+jwt alg=selectedAlg jwk=DPoP public JWK]
+    H --> I[Sign internally with the library DPoP private key]
+    I --> J([Set tokenRequest.dpopProof = signed dpop+jwt\nwallet copies it into the DPoP header])
 ```
 
-### Flow 5 — Credential Endpoint DPoP Proof Construction (Library)
+---
 
-The library constructs the proof. The wallet only provides the signature.
+### Flow 5 — Credential Endpoint DPoP (Library, fully internal)
+
+The library constructs, signs, sends, and retries. The wallet is not involved.
 
 ```mermaid
 flowchart TD
     A([Library about to call credential endpoint]) --> B{token_type in\ntoken response == DPoP?}
     B -- No --> BN([Use Authorization=Bearer\nno DPoP proof])
-    B -- Yes --> C[Select alg from clientMetadata.dpop.keys\nvs dpop_signing_alg_values_supported]
+    B -- Yes --> C[Use selected alg + library DPoP key]
     C --> D[Generate UUID v4 as jti]
-    D --> E[Compute ath = base64url of SHA-256 of access_token]
+    D --> E[Compute ath = base64url SHA-256 of access_token]
     E --> F{RS nonce available\nfrom prior 401?}
     F -- Yes --> G[Include nonce claim]
     F -- No --> H[Omit nonce claim]
-    G --> I[Build JWT header+payload\ntyp=dpop+jwt alg htm=POST htu iat exp jti ath\njwk=matching public key from dpop.keys\nnonce if present]
+    G --> I[Build header+payload\ntyp=dpop+jwt alg htm=POST htu iat exp jti ath nonce?\njwk=DPoP public JWK]
     H --> I
-    I --> J[fire onRequestDPoPSign\nsigningInput=base64url-header.base64url-payload\nalg=selectedAlg]
-    J --> K[Wallet signs with DPoP_selectedAlg alias]
-    K --> L[Wallet returns base64url signature]
-    L --> M[Library assembles header.payload.signature]
-    M --> N([Set DPoP header and Authorization=DPoP header\nmake credential HTTP request])
+    I --> J[Sign internally with library DPoP private key]
+    J --> N([Set DPoP + Authorization=DPoP headers\nmake credential HTTP request])
     N --> O{401 response?}
     O -- No --> P([Done])
     O -- Yes --> Q{WWW-Authenticate\ncontains DPoP challenge?}
-    Q -- Yes --> R[Handle DPoP errors\nnonce=extract DPoP-Nonce and retry\nother=propagate error]
+    Q -- Yes --> R[nonce error → store DPoP-Nonce, rebuild+resign, retry\nother → propagate error]
     R --> D
-    Q -- No --> S[WWW-Authenticate=Bearer only\nbest-effort Bearer retry per RFC9449 sect7.2\nnot guaranteed to succeed]
+    Q -- No --> S[WWW-Authenticate=Bearer only\nbest-effort Bearer retry per RFC9449 §7.2\nnot guaranteed]
     S --> T([Retry with Authorization=Bearer\nno DPoP proof])
 ```
 
@@ -383,35 +321,36 @@ flowchart TD
 stateDiagram-v2
     direction LR
 
-    state "Token Request - Wallet JS" as TR {
-        [*] --> SendProofA : build proof-A no nonce
+    state "Token Request — wallet relays, library signs" as TR {
+        [*] --> SendProofA : library supplies proof-A (no nonce) on tokenRequest.dpopProof
         SendProofA --> TokenOK : 200 OK
         SendProofA --> NonceRequired : 400 use_dpop_nonce
-        NonceRequired --> StoreASNonce : read DPoP-Nonce from error response
-        StoreASNonce --> SendProofB : build proof-B with AS nonce
+        NonceRequired --> AskLibrary : wallet reads DPoP-Nonce, calls generateTokenDPoPProof(nonce)
+        AskLibrary --> SendProofB : library returns signed proof-B with nonce
         SendProofB --> TokenOK : 200 OK
-        TokenOK --> CheckSuccessNonce : read DPoP-Nonce from 200 response
-        CheckSuccessNonce --> [*] : store as dpopASNonce for next token request
+        TokenOK --> [*] : wallet returns TokenResponse to library
     }
 
-    state "Credential Request - Library internal" as CR {
-        [*] --> AskWalletSign : fire onRequestDPoPSign no RS nonce yet
-        AskWalletSign --> CredOK : 200 OK
-        AskWalletSign --> RSNonceRequired : 401 use_dpop_nonce
+    state "Credential Request — library internal" as CR {
+        [*] --> Sign : library builds + signs proof (no RS nonce yet)
+        Sign --> CredOK : 200 OK
+        Sign --> RSNonceRequired : 401 use_dpop_nonce
         RSNonceRequired --> StoreRSNonce : library stores DPoP-Nonce internally
-        StoreRSNonce --> AskWalletSignRetry : fire onRequestDPoPSign with RS nonce in proof
-        AskWalletSignRetry --> CredOK : 200 OK
+        StoreRSNonce --> SignRetry : library rebuilds + re-signs with RS nonce
+        SignRetry --> CredOK : 200 OK
         CredOK --> [*] : credential issued
     }
 
     [*] --> TR
-    TR --> CR : access token sent to library
+    TR --> CR : access token returned to library
     CR --> [*] : credential issued
 ```
 
 ---
 
-### Flow 7 — XState Machine State Changes
+### Flow 7 — XState Machine State Changes (wallet side)
+
+DPoP keys and signing leave the wallet entirely. No `ensuringDPoPKeys` state, no `signingDPoP` state. The only change is inside the existing token-request state.
 
 ```mermaid
 stateDiagram-v2
@@ -422,59 +361,47 @@ stateDiagram-v2
     state "EXISTING STATES" as existing {
         idle --> checkingIssuerTrust
         checkingIssuerTrust --> credentialOfferConsent
-        credentialOfferConsent --> ensuringDPoPKeys
+        credentialOfferConsent --> authOrToken
     }
 
-    state "NEW ensuringDPoPKeys" as ensuringDPoPKeys {
-        [*] --> loadAllKeys : load DPoP_ES256 DPoP_RS256 DPoP_EdDSA DPoP_ES256K from storage
-        loadAllKeys --> generateMissing : generate and store any absent keys
-        generateMissing --> [*] : dpopKeys map in context with all public JWKs
-    }
-
-    ensuringDPoPKeys --> authRedirect : auth code flow\nlibrary includes dpop_jkt in auth URL
-    ensuringDPoPKeys --> tokenRequest : pre-auth flow
+    authOrToken --> authRedirect : auth code flow\nlibrary already put dpop_jkt in the auth URL
+    authOrToken --> tokenRequest : pre-auth flow
 
     authRedirect --> waitingForAuthCode
     waitingForAuthCode --> tokenRequest : auth code received
 
     state "MODIFIED tokenRequest" as tokenRequest {
-        [*] --> sendWithDPoP : sendTokenRequest with DPoP header\nusing pre-selected alg + dpopASNonce
-        sendWithDPoP --> tokenOK : 200 DPoP token
+        [*] --> sendWithDPoP : POST /token with DPoP = tokenRequest.dpopProof
+        sendWithDPoP --> tokenOK : 200 token
         sendWithDPoP --> nonceError : 400 use_dpop_nonce
     }
 
     state "NEW retryTokenWithNonce" as retryNonce {
-        [*] --> storeNonce : store dpopASNonce from 400 response
-        storeNonce --> retry : sendTokenRequest again with nonce in proof
-        retry --> [*] : 200 DPoP token
+        [*] --> askLibrary : read DPoP-Nonce, call generateTokenDPoPProof(nonce)
+        askLibrary --> retry : POST /token again with the returned proof
+        retry --> [*] : 200 token
     }
 
     tokenRequest --> retryNonce : use_dpop_nonce error
-    tokenRequest --> sendTokenResponse : success
-    retryNonce --> sendTokenResponse : success
+    tokenRequest --> returnTokenResponse : success
+    retryNonce --> returnTokenResponse : success
 
-    sendTokenResponse --> idle : token and clientMetadata delivered to library
+    returnTokenResponse --> idle : TokenResponse returned to library
 
-    idle --> constructProof : onRequestProof event
-    constructProof --> idle : openid4vci-proof+jwt sent
-
-    state "NEW signingDPoP" as signingDPoP {
-        [*] --> sign : RNSecureKeystoreModule.sign\nalias=DPoP_alg from event\ninput=signingInput from event
-        sign --> [*] : sendDPoPSignatureFromJS
-    }
-
-    idle --> signingDPoP : onRequestDPoPSign event from library
-    signingDPoP --> idle
+    idle --> constructProof : getProofs callback (credential proof key — unchanged)
+    constructProof --> idle : openid4vci-proof+jwt returned
 ```
 
 ---
 
 ## Key Separation
 
+DPoP keys are owned by the library; the credential proof key stays wallet-owned. They are never the same key.
+
 ```mermaid
 graph LR
-    DPoP["DPoP Keys\nDPoP_ES256 DPoP_RS256\nDPoP_EdDSA DPoP_ES256K"] --> T["Token endpoint DPoP proof\nCredential endpoint DPoP proof"]
-    Proof["Credential Proof Key\nOpenId4VCI_KeyPair"] --> P["openid4vci-proof+jwt\nin credential request body"]
+    DPoP["DPoP Key (library-owned, ephemeral, in-memory per flow)"] --> T["Token endpoint DPoP proof\nCredential endpoint DPoP proof\nboth built + signed in the library"]
+    Proof["Credential Proof Key (wallet-owned)"] --> P["openid4vci-proof+jwt\nvia getProofs callback (unchanged)"]
 ```
 
 ---
@@ -484,23 +411,24 @@ graph LR
 ### Positive
 
 - Access tokens are sender-constrained — a stolen token is useless without the DPoP private key.
-- All four wallet key types (ES256, RS256, EdDSA, ES256K) are available for DPoP — interoperable with any AS regardless of which alg it supports.
-- Library handles RS nonce and retry loop — wallet has no RS nonce state to manage.
-- No new native method parameters — DPoP config travels inside the existing `clientMetadata` JSON.
-- `token_type` in the token response drives the credential endpoint decision — wallet and library don't need to coordinate on a DPoP/Bearer flag separately.
-- `dpop_jkt` binding prevents auth code injection (read: RFC 9449 §11.9).
-- Nonce support prevents proof pre-generation (read: RFC 9449 §11.2).
+- **Ephemeral keys have nothing to steal at rest and no rotation policy.** The private key lives only in memory for one flow, so the "long-lived key exfiltrated from the keystore" threat class does not apply, and rotation is inherent.
+- **Better privacy / unlinkability.** A fresh `jkt` per flow prevents an AS or issuer from correlating separate issuance flows by a stable key thumbprint.
+- **One owner for DPoP.** Proof structure, alg selection, key binding, signing, nonce handling, and retries all live in the library. There is no cross-boundary state to keep in sync and no signing closure handed to the wallet.
+- **Wallet surface is tiny.** The wallet copies `tokenRequest.dpopProof` into a header and, on a nonce challenge, calls one library method. It never reads AS metadata, picks an alg, holds a DPoP key, or signs.
+- `ClientMetadata` is unchanged; the credential proof callback (`getProofs`) is unchanged.
+- `token_type` in the token response drives the credential-endpoint decision internally — no separate DPoP/Bearer flag to coordinate.
+- `dpop_jkt` binding prevents auth code injection (read: RFC 9449 §11.9); nonce support prevents proof pre-generation (read: RFC 9449 §11.2).
 
 ### Trade-offs
 
-- **`ensuringDPoPKeys` generates up to four key pairs on first run.** Subsequent flows load from storage — cost is one-time.
-- **dpop_jkt alg coordination is implicit.** Wallet and library independently apply the same preference order to the same key list and AS metadata — they must agree. Any divergence in preference order between wallet and library would cause a mismatch.
-- **VCIClient library requires changes.** `ClientMetadata.dpop`, `signDPoP` closure, and internal RS nonce handling must be added upstream.
-- **`dpop_signing_alg_values_supported` is optional in RFC 9449.** When absent, wallet uses its own preference order (ES256 first) and still attempts DPoP. AS ignores an unrecognised DPoP header and returns a Bearer token if it doesn't support DPoP — `token_type` in the response is the actual outcome signal.
-- **Bearer fallback on credential endpoint 401 is best-effort.** RFC 9449 §7.2 uses "would most presumably accept" — a DPoP-aware RS that only sent a Bearer challenge would still reject the downgraded request.
+- **The library gains in-memory keygen + signing responsibility it did not have before (OQ-2).** `VCIClient` previously delegated all signing to the wallet via `getProofs`. DPoP now requires in-memory key generation and signing in both the Swift and Kotlin libraries — but no secure persistent storage, since keys never outlive a flow.
+- **Ephemeral keys cannot survive an app restart or a long-deferred poll (OQ-3).** Today's flows are synchronous, so this is a non-issue; deferred or resumable issuance would need a persisted key or a fresh authorization.
+- **One extra wallet→library round trip on a nonce challenge.** The AS `use_dpop_nonce` path costs a `generateTokenDPoPProof` call before the retry POST. This is the price of keeping the token HTTP request wallet-side while the proof stays library-built.
+- **`dpop_signing_alg_values_supported` is optional in RFC 9449.** When absent, the library uses its own preference order (ES256 first) and still attempts DPoP. The AS returns a Bearer token if it does not support DPoP — `token_type` in the response is the actual outcome signal.
+- **Bearer fallback on a credential-endpoint 401 is best-effort.** RFC 9449 §7.2 uses "would most presumably accept" — a DPoP-aware RS that only sent a Bearer challenge could still reject the downgraded request.
 
 ### Non-goals
 
 - DPoP for VP presentation flows (OpenID4VP) — out of scope.
 - DPoP for the wallet binding (WLA) endpoint — separate flow.
-- Refresh token DPoP binding — wallet does not use refresh tokens in OID4VCI flows today.
+- Refresh token DPoP binding — the wallet does not use refresh tokens in OID4VCI flows today.

--- a/docs/# ADR: DPoP Sender-Constrained Access To.md
+++ b/docs/# ADR: DPoP Sender-Constrained Access To.md
@@ -53,28 +53,31 @@ OID4VCI 1.0 draft-13 mandates DPoP support as the mechanism for sender-constrain
 
 ### Key design
 
-| Concern                                   | Decision                                                                                                                            |
-| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| DPoP key algorithms                       | One persistent key pair per supported alg: `DPoP_ES256`, `DPoP_RS256`, `DPoP_EdDSA`, `DPoP_ES256K`                                  |
-| DPoP key storage                          | `RNSecureKeystoreModule` generic key storage, one alias per alg                                                                     |
-| DPoP key generation                       | Per-alg: generated once on first use, loaded from alias on subsequent flows                                                         |
-| DPoP key rotation                         | **Open question** — RFC 9449 is silent on rotation frequency. Policy TBD (wallet reset / periodic / never)                          |
-| DPoP key vs credential proof key          | Always separate — using the same key for both enables JWT-swapping attacks (read: RFC 9449 §11.5)                                   |
-| Alg selection — credential endpoint       | Library picks from `clientMetadata.dpop.keys` intersected with AS `dpop_signing_alg_values_supported`                               |
-| Alg selection — token endpoint + dpop_jkt | Wallet pre-selects using `selectCredentialRequestKey()` against AS metadata (same preference order the library uses, so they agree) |
-| DPoP config transport                     | Embedded in existing `clientMetadata` JSON as `dpop.keys` — no new native method parameters                                         |
-| clientMetadata ownership                  | Built in `IssuersService` for both flows; `VciClient.ts` no longer hardcodes it                                                     |
-| AS nonce                                  | Wallet JS owns: read from token endpoint response, stored as `dpopASNonce` in XState context                                        |
-| RS nonce                                  | Library owns: extracted from 401 response internally, passed as `signingInput` context to wallet on retry — wallet never stores it  |
-| Auth code binding                         | Wallet computes `dpop_jkt` from the pre-selected DPoP key and appends to auth URL (read: RFC 9449 §10)                              |
-| Pre-auth code flow                        | No `dpop_jkt` — just `DPoP` header on token request                                                                                 |
-| Graceful degradation                      | Absent `dpop_signing_alg_values_supported` in AS metadata → skip DPoP, use Bearer                                                   |
+| Concern                                    | Decision                                                                                                                                                                                                                                                                                                 |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| DPoP key algorithms                        | One persistent key pair per supported alg: `DPoP_ES256`, `DPoP_RS256`, `DPoP_EdDSA`, `DPoP_ES256K`                                                                                                                                                                                                       |
+| DPoP key storage                           | `RNSecureKeystoreModule` generic key storage, one alias per alg                                                                                                                                                                                                                                          |
+| DPoP key generation                        | Per-alg: generated once on first use, loaded from alias on subsequent flows                                                                                                                                                                                                                              |
+| DPoP key rotation                          | **Open question** — RFC 9449 is silent on rotation frequency. Policy TBD (wallet reset / periodic / never)                                                                                                                                                                                               |
+| DPoP key vs credential proof key           | Always separate — using the same key for both enables JWT-swapping attacks (read: RFC 9449 §11.5)                                                                                                                                                                                                        |
+| Alg selection — credential endpoint        | Library picks from `clientMetadata.dpop.keys` intersected with AS `dpop_signing_alg_values_supported`                                                                                                                                                                                                    |
+| Alg selection — token endpoint + dpop_jkt  | Wallet pre-selects using `selectCredentialRequestKey()` against AS metadata (same preference order the library uses, so they agree)                                                                                                                                                                      |
+| DPoP config transport                      | Embedded in existing `clientMetadata` JSON as `dpop.keys` — no new native method parameters                                                                                                                                                                                                              |
+| clientMetadata ownership                   | Built in `IssuersService` for both flows; `VciClient.ts` no longer hardcodes it                                                                                                                                                                                                                          |
+| AS nonce                                   | Wallet JS owns: read from token endpoint response, stored as `dpopASNonce` in XState context                                                                                                                                                                                                             |
+| RS nonce                                   | Library owns: extracted from 401 response internally, passed as `signingInput` context to wallet on retry — wallet never stores it                                                                                                                                                                       |
+| Auth code binding                          | Wallet computes `dpop_jkt` from the pre-selected DPoP key and appends to auth URL (read: RFC 9449 §10)                                                                                                                                                                                                   |
+| Pre-auth code flow                         | No `dpop_jkt` — just `DPoP` header on token request                                                                                                                                                                                                                                                      |
+| DPoP attempt — token endpoint              | Always attempt DPoP on the token request (OID4VCI recommends DPoP). `dpop_signing_alg_values_supported` present → use for alg selection. Absent → use wallet's preference order (ES256 first). Check `token_type` in response to confirm whether AS issued a DPoP-bound or Bearer token.                 |
+| Graceful degradation — credential endpoint | Library checks `token_type` from token response. `token_type: "DPoP"` → use DPoP with `ath`. `token_type: "Bearer"` → use Bearer, ignore `clientMetadata.dpop` entirely.                                                                                                                                 |
+| RS Bearer-only 401 fallback                | If credential endpoint returns 401 with `WWW-Authenticate: Bearer` only (no DPoP challenge) → spec §7.2 permits retrying with Bearer as best-effort. Not guaranteed — RS could still reject. If `WWW-Authenticate: DPoP` is present (with or without Bearer) → never downgrade, handle DPoP errors only. |
 
 ### Open questions
 
-| #    | Question                                                                                                       | Impact                    |
-| ---- | -------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| OQ-1 | **DPoP key rotation frequency** — RFC 9449 is silent. Options: wallet reset, time-based (e.g. 90 days), never. | Key management complexity |
+| #    | Question                                                                                                                                                                                                                                                                               | Impact                    |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| OQ-1 | **DPoP key rotation frequency** — RFC 9449 is silent. Options: wallet reset, time-based (e.g. 90 days), never.                                                                                                                                                                         | Key management complexity |
+| OQ-2 | **AS rejects DPoP header despite OID4VCI recommendation** — wallet sends DPoP, AS returns error (not `use_dpop_nonce`). Should wallet retry as Bearer or hard-fail? Policy call: retrying as Bearer degrades security; hard-failing is safer but breaks interop with non-compliant AS. | Degradation policy        |
 
 ---
 
@@ -209,13 +212,15 @@ flowchart TD
     A([Start issuance flow]) --> B[Fetch issuer well-known\n/.well-known/openid-credential-issuer]
     B --> C[Resolve AS endpoint\nfrom authorization_servers field\nor use issuer host if absent]
     C --> D[Fetch AS well-known\n/.well-known/oauth-authorization-server]
-    D --> E{dpop_signing_alg_values\n_supported present in AS metadata?}
-    E -- No --> F([Continue without DPoP\nBearer flow])
-    E -- Yes --> G[For each alg in ES256 RS256 EdDSA ES256K\nload DPoP key from storage\ngenerate and store if absent]
+    D --> G[For each alg in ES256 RS256 EdDSA ES256K\nload DPoP key from storage\ngenerate and store if absent]
     G --> H[Build clientMetadata.dpop.keys\nwith all public key JWKs]
-    H --> I{Auth code flow?}
-    I -- Yes --> J[Pre-select alg for dpop_jkt\nselectCredentialRequestKey\nagainst dpop_signing_alg_values_supported]
-    I -- No --> K([Proceed to token request])
+    H --> I1{dpop_signing_alg_values\n_supported present?}
+    I1 -- Yes --> I2[Select alg from intersection\nof wallet keys and AS-supported algs]
+    I1 -- No --> I3[Use wallet preference order\nES256 first\nfield is optional per RFC9449]
+    I2 --> I{Auth code flow?}
+    I3 --> I
+    I -- Yes --> J[Pre-select alg for dpop_jkt\nusing chosen alg above]
+    I -- No --> K([Proceed to token request with DPoP])
     J --> L[Compute dpop_jkt = JWK thumbprint\nof pre-selected DPoP key]
     L --> M([Append dpop_jkt to auth URL\nthen proceed])
 ```
@@ -355,23 +360,28 @@ The library constructs the proof. The wallet only provides the signature.
 
 ```mermaid
 flowchart TD
-    A([Library about to call credential endpoint]) --> B[Select alg from clientMetadata.dpop.keys\nvs dpop_signing_alg_values_supported]
-    B --> C[Generate UUID v4 as jti]
-    C --> D[Compute ath = base64url of SHA-256 of access_token]
-    D --> E{RS nonce available\nfrom prior 401?}
-    E -- Yes --> F[Include nonce claim]
-    E -- No --> G[Omit nonce claim]
-    F --> H[Build JWT header+payload\ntyp=dpop+jwt alg htm=POST htu iat exp jti ath\njwk=matching public key from dpop.keys\nnonce if present]
-    G --> H
-    H --> I[fire onRequestDPoPSign\nsigningInput=base64url-header.base64url-payload\nalg=selectedAlg]
-    I --> J[Wallet signs with DPoP_selectedAlg alias]
-    J --> K[Wallet returns base64url signature]
-    K --> L[Library assembles header.payload.signature]
-    L --> M([Set DPoP header and Authorization=DPoP header\nmake credential HTTP request])
-    M --> N{401 use_dpop_nonce?}
-    N -- Yes --> O[Extract DPoP-Nonce from response\nstore internally]
-    O --> C
-    N -- No --> P([Done])
+    A([Library about to call credential endpoint]) --> B{token_type in\ntoken response == DPoP?}
+    B -- No --> BN([Use Authorization=Bearer\nno DPoP proof])
+    B -- Yes --> C[Select alg from clientMetadata.dpop.keys\nvs dpop_signing_alg_values_supported]
+    C --> D[Generate UUID v4 as jti]
+    D --> E[Compute ath = base64url of SHA-256 of access_token]
+    E --> F{RS nonce available\nfrom prior 401?}
+    F -- Yes --> G[Include nonce claim]
+    F -- No --> H[Omit nonce claim]
+    G --> I[Build JWT header+payload\ntyp=dpop+jwt alg htm=POST htu iat exp jti ath\njwk=matching public key from dpop.keys\nnonce if present]
+    H --> I
+    I --> J[fire onRequestDPoPSign\nsigningInput=base64url-header.base64url-payload\nalg=selectedAlg]
+    J --> K[Wallet signs with DPoP_selectedAlg alias]
+    K --> L[Wallet returns base64url signature]
+    L --> M[Library assembles header.payload.signature]
+    M --> N([Set DPoP header and Authorization=DPoP header\nmake credential HTTP request])
+    N --> O{401 response?}
+    O -- No --> P([Done])
+    O -- Yes --> Q{WWW-Authenticate\ncontains DPoP challenge?}
+    Q -- Yes --> R[Handle DPoP errors\nnonce=extract DPoP-Nonce and retry\nother=propagate error]
+    R --> D
+    Q -- No --> S[WWW-Authenticate=Bearer only\nbest-effort Bearer retry per RFC9449 sect7.2\nnot guaranteed to succeed]
+    S --> T([Retry with Authorization=Bearer\nno DPoP proof])
 ```
 
 ---
@@ -486,7 +496,7 @@ graph LR
 - All four wallet key types (ES256, RS256, EdDSA, ES256K) are available for DPoP — interoperable with any AS regardless of which alg it supports.
 - Library handles RS nonce and retry loop — wallet has no RS nonce state to manage.
 - No new native method parameters — DPoP config travels inside the existing `clientMetadata` JSON.
-- Compatible with ASes enforcing `dpop_bound_access_tokens: true`.
+- `token_type` in the token response drives the credential endpoint decision — wallet and library don't need to coordinate on a DPoP/Bearer flag separately.
 - `dpop_jkt` binding prevents auth code injection (read: RFC 9449 §11.9).
 - Nonce support prevents proof pre-generation (read: RFC 9449 §11.2).
 
@@ -495,6 +505,8 @@ graph LR
 - **`ensuringDPoPKeys` generates up to four key pairs on first run.** Subsequent flows load from storage — cost is one-time.
 - **dpop_jkt alg coordination is implicit.** Wallet and library independently apply the same preference order to the same key list and AS metadata — they must agree. Any divergence in preference order between wallet and library would cause a mismatch.
 - **VCIClient library requires changes.** `ClientMetadata.dpop`, `signDPoP` closure, and internal RS nonce handling must be added upstream.
+- **`dpop_signing_alg_values_supported` is optional in RFC 9449.** When absent, wallet uses its own preference order (ES256 first) and still attempts DPoP. AS ignores an unrecognised DPoP header and returns a Bearer token if it doesn't support DPoP — `token_type` in the response is the actual outcome signal.
+- **Bearer fallback on credential endpoint 401 is best-effort.** RFC 9449 §7.2 uses "would most presumably accept" — a DPoP-aware RS that only sent a Bearer challenge would still reject the downgraded request.
 
 ### Non-goals
 

--- a/docs/# ADR: DPoP Sender-Constrained Access To.md
+++ b/docs/# ADR: DPoP Sender-Constrained Access To.md
@@ -1,0 +1,503 @@
+# ADR: DPoP Sender-Constrained Access Tokens (RFC 9449)
+
+| Field               | Value                                                                    |
+| ------------------- | ------------------------------------------------------------------------ |
+| **Status**          | Proposed                                                                 |
+| **Date**            | 2026-06-16                                                               |
+| **Spec references** | [RFC 9449](https://www.rfc-editor.org/rfc/rfc9449), OID4VCI 1.0 draft-13 |
+| **Branch**          | `feat/dpop`                                                              |
+
+---
+
+## Context
+
+The wallet currently exchanges authorization grants for Bearer access tokens and presents them to the credential endpoint as `Authorization: Bearer <token>`. Bearer tokens are not bound to any client identity — anyone who intercepts or exfiltrates a token can replay it against any resource server.
+
+RFC 9449 (DPoP — Demonstrating Proof of Possession) adds sender-constraint to OAuth 2.0 access tokens by cryptographically binding each token to a client-controlled key pair. The wallet must prove possession of the private key on every request that uses the token. A stolen token is therefore useless without the corresponding private key.
+
+OID4VCI 1.0 draft-13 mandates DPoP support as the mechanism for sender-constrained access tokens at both the authorization server (token endpoint) and the credential issuer (credential endpoint).
+
+### Current gaps
+
+- `sendTokenRequest` (JS) sends a plain `fetch()` with no `DPoP` header.
+- The credential endpoint is called by the native `VCIClient` library with `Authorization: Bearer`.
+- No DPoP key management, proof construction, or nonce handling exists anywhere.
+
+---
+
+## Decision Drivers
+
+- **Security:** Prevent access token replay after exfiltration (BREACH, Heartbleed, XSS-class attacks as cited in RFC 9449 §2).
+- **Interoperability:** Be compatible with AS and RS that enforce `dpop_bound_access_tokens: true`. Support all key types the wallet already has.
+- **Spec compliance:** OID4VCI 1.0 d13 requires DPoP for sender-constrained token flows.
+- **Minimal disruption:** The token request is already JS-owned. The credential request is native — extend the bridge without forking VCIClient internals.
+- **Separation of concerns:** The library knows HTTP context (htm, htu, nonce from RS). The wallet knows keys and signing. Each does what it knows.
+
+---
+
+## Plan
+
+### Split responsibility: library constructs proofs, wallet signs ✓
+
+**Token endpoint (JS-owned):** Wallet constructs the full DPoP proof and adds the `DPoP` header in `sendTokenRequest`. AS nonce is managed entirely in JS.
+
+**Credential endpoint (library-owned):** The VCIClient library constructs DPoP proofs internally — it already knows `htm`, `htu`, `accessToken`, and any RS-provided nonce from 401 responses. The library fires an `onRequestDPoPSign` callback with the `signingInput` (the `header.payload` bytes to sign) and which `alg` it chose. The wallet signs using the matching DPoP key alias and returns the raw signature. The library assembles the final JWT and injects the headers.
+
+**Key negotiation:** The wallet passes all available DPoP public keys (one per supported alg) inside `clientMetadata.dpop.keys`. The library intersects this with `dpop_signing_alg_values_supported` from AS metadata and picks the best match. The wallet never needs to read AS metadata for DPoP key selection.
+
+**Chosen.** Clean separation: library owns protocol (proof structure, RS nonce, retry), wallet owns keys (generation, storage, signing). No new native method parameters — all DPoP config travels inside the existing `clientMetadata` JSON string.
+
+---
+
+## Decision
+
+### Key design
+
+| Concern                                   | Decision                                                                                                                            |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| DPoP key algorithms                       | One persistent key pair per supported alg: `DPoP_ES256`, `DPoP_RS256`, `DPoP_EdDSA`, `DPoP_ES256K`                                  |
+| DPoP key storage                          | `RNSecureKeystoreModule` generic key storage, one alias per alg                                                                     |
+| DPoP key generation                       | Per-alg: generated once on first use, loaded from alias on subsequent flows                                                         |
+| DPoP key rotation                         | **Open question** — RFC 9449 is silent on rotation frequency. Policy TBD (wallet reset / periodic / never)                          |
+| DPoP key vs credential proof key          | Always separate — using the same key for both enables JWT-swapping attacks (read: RFC 9449 §11.5)                                   |
+| Alg selection — credential endpoint       | Library picks from `clientMetadata.dpop.keys` intersected with AS `dpop_signing_alg_values_supported`                               |
+| Alg selection — token endpoint + dpop_jkt | Wallet pre-selects using `selectCredentialRequestKey()` against AS metadata (same preference order the library uses, so they agree) |
+| DPoP config transport                     | Embedded in existing `clientMetadata` JSON as `dpop.keys` — no new native method parameters                                         |
+| clientMetadata ownership                  | Built in `IssuersService` for both flows; `VciClient.ts` no longer hardcodes it                                                     |
+| AS nonce                                  | Wallet JS owns: read from token endpoint response, stored as `dpopASNonce` in XState context                                        |
+| RS nonce                                  | Library owns: extracted from 401 response internally, passed as `signingInput` context to wallet on retry — wallet never stores it  |
+| Auth code binding                         | Wallet computes `dpop_jkt` from the pre-selected DPoP key and appends to auth URL (read: RFC 9449 §10)                              |
+| Pre-auth code flow                        | No `dpop_jkt` — just `DPoP` header on token request                                                                                 |
+| Graceful degradation                      | Absent `dpop_signing_alg_values_supported` in AS metadata → skip DPoP, use Bearer                                                   |
+
+### Open questions
+
+| #    | Question                                                                                                       | Impact                    |
+| ---- | -------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| OQ-1 | **DPoP key rotation frequency** — RFC 9449 is silent. Options: wallet reset, time-based (e.g. 90 days), never. | Key management complexity |
+
+---
+
+## DPoP Proof JWT Structure (RFC 9449 §4.2)
+
+```
+Header:
+{
+  "typ": "dpop+jwt",
+  "alg": "ES256",
+  "jwk": { "kty":"EC", "crv":"P-256", "x":"...", "y":"..." }  ← public key only, no private
+}
+
+Payload:
+{
+  "jti": "<UUID v4>",                    ← unique per proof, never reuse
+  "htm": "POST",                         ← HTTP method of the target request
+  "htu": "https://issuer.example/token", ← target URI, no query string, no fragment
+  "iat": 1718500000,
+  "exp": 1718500060,                     ← short-lived: iat + 60s
+  "nonce": "aaaa...",                    ← only when server has demanded one
+  "ath": "base64url(SHA-256(token))"     ← only at resource server (credential endpoint)
+}
+```
+
+`ath` is absent on the token endpoint request. Mandatory on the credential endpoint request.
+
+---
+
+## Library API Changes
+
+### `ClientMetadata` struct extension
+
+The VCIClient library's `ClientMetadata` gains an optional `dpop` field. No existing fields change; no new method parameters are added anywhere.
+
+```swift
+// VCIClient library — ClientMetadata
+struct DPoPKeyEntry: Codable {
+  let alg: String           // "ES256" | "RS256" | "EdDSA" | "ES256K"
+  let publicKeyJWK: AnyCodable
+}
+
+struct DPoPConfig: Codable {
+  let keys: [DPoPKeyEntry]  // all DPoP public keys the wallet holds
+}
+
+struct ClientMetadata: Codable {
+  let clientId: String
+  let redirectUri: String
+  let dpop: DPoPConfig?     // nil → library uses Bearer only
+}
+```
+
+Equivalent TypeScript type used by `IssuersService` when building `clientMetadata`:
+
+```typescript
+type ClientMetadata = {
+  clientId: string;
+  redirectUri: string;
+  dpop?: {
+    keys: Array<{alg: string; publicKeyJWK: object}>;
+  };
+};
+```
+
+### `fetchCredentialsUsingCredentialOffer` / `fetchCredentialsFromTrustedIssuer` — new `signDPoP` closure
+
+The library gains one new optional closure parameter. All existing parameters are unchanged.
+
+```swift
+// Added to both fetch methods — nil when dpop is absent from ClientMetadata
+signDPoP: ((_ signingInput: String, _ alg: String) async throws -> String)?
+```
+
+The library calls this closure each time it needs a DPoP proof signed. It constructs the JWT header and payload internally, serialises to `base64url(header).base64url(payload)`, and passes that as `signingInput`. The wallet returns `base64url(signature)`. The library appends the signature to form the complete JWT.
+
+### `onRequestDPoPSign` event / `sendDPoPSignatureFromJS` receiver
+
+Mirrors the existing `onRequestProof` / `sendProofFromJS` pattern exactly.
+
+```
+Native → JS event: onRequestDPoPSign
+  { "signingInput": "eyJ...", "alg": "ES256" }
+
+JS → Native receiver: sendDPoPSignatureFromJS
+  "MEYCIQDnp3..."   ← base64url(ES256 signature over signingInput bytes)
+```
+
+### `clientMetadata` on the wire
+
+```json
+{
+  "clientId": "wallet",
+  "redirectUri": "io.mosip.residentapp.inji://oauthredirect",
+  "dpop": {
+    "keys": [
+      {
+        "alg": "ES256",
+        "publicKeyJWK": {"kty": "EC", "crv": "P-256", "x": "...", "y": "..."}
+      },
+      {"alg": "RS256", "publicKeyJWK": {"kty": "RSA", "n": "...", "e": "AQAB"}},
+      {
+        "alg": "EdDSA",
+        "publicKeyJWK": {"kty": "OKP", "crv": "Ed25519", "x": "..."}
+      },
+      {
+        "alg": "ES256K",
+        "publicKeyJWK": {
+          "kty": "EC",
+          "crv": "secp256k1",
+          "x": "...",
+          "y": "..."
+        }
+      }
+    ]
+  }
+}
+```
+
+If no DPoP keys exist or AS does not support DPoP, `dpop` field is omitted and library falls back to Bearer.
+
+---
+
+## Flow Diagrams
+
+### Flow 1 — DPoP Key Setup (both flows)
+
+Runs once at start of each issuance flow. The wallet ensures all DPoP key pairs exist in storage and assembles the full key list for `clientMetadata`. The library will pick the alg.
+
+```mermaid
+flowchart TD
+    A([Start issuance flow]) --> B[Fetch issuer well-known\n/.well-known/openid-credential-issuer]
+    B --> C[Resolve AS endpoint\nfrom authorization_servers field\nor use issuer host if absent]
+    C --> D[Fetch AS well-known\n/.well-known/oauth-authorization-server]
+    D --> E{dpop_signing_alg_values\n_supported present in AS metadata?}
+    E -- No --> F([Continue without DPoP\nBearer flow])
+    E -- Yes --> G[For each alg in ES256 RS256 EdDSA ES256K\nload DPoP key from storage\ngenerate and store if absent]
+    G --> H[Build clientMetadata.dpop.keys\nwith all public key JWKs]
+    H --> I{Auth code flow?}
+    I -- Yes --> J[Pre-select alg for dpop_jkt\nselectCredentialRequestKey\nagainst dpop_signing_alg_values_supported]
+    I -- No --> K([Proceed to token request])
+    J --> L[Compute dpop_jkt = JWK thumbprint\nof pre-selected DPoP key]
+    L --> M([Append dpop_jkt to auth URL\nthen proceed])
+```
+
+---
+
+### Flow 2 — Pre-Authorized Code Flow with DPoP
+
+Token endpoint: wallet JS constructs full DPoP proof.
+Credential endpoint: library constructs proof, wallet only signs.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant W as Wallet JS
+    participant L as VCIClient Library
+    participant AS as Authorization Server
+    participant CI as Credential Issuer
+
+    W->>AS: GET /.well-known/oauth-authorization-server
+    AS-->>W: 200 metadata with dpop_signing_alg_values_supported
+    W->>W: Ensure all DPoP key pairs in storage
+    W->>W: Build clientMetadata with dpop.keys list
+    note over W: pre-authorized_code and optional tx_code already in context
+
+    note over W: Token endpoint — wallet owns this request
+    W->>W: Pre-select alg using selectCredentialRequestKey
+    W->>W: Build DPoP proof-A htm=POST htu=token_endpoint no ath no nonce
+    W->>AS: POST /token DPoP=proof-A grant_type=pre-authorized_code pre-authorized_code=X tx_code=Y
+    AS-->>W: 400 error=use_dpop_nonce DPoP-Nonce=nonce-as-1
+    note over W: Store nonce-as-1 as dpopASNonce in XState context
+    W->>W: Build DPoP proof-B with nonce=nonce-as-1
+    W->>AS: POST /token DPoP=proof-B grant_type=pre-authorized_code pre-authorized_code=X tx_code=Y
+    AS-->>W: 200 access_token=T token_type=DPoP DPoP-Nonce=nonce-as-2
+    note over W: Validate token_type equals DPoP. Store nonce-as-2 as dpopASNonce.
+    W->>L: sendTokenResponse with access_token=T
+
+    note over L,CI: Credential endpoint — library owns this request
+    L->>L: Select alg from clientMetadata.dpop.keys vs AS metadata
+    L->>L: Build proof header+payload htm=POST htu=credential_endpoint ath=SHA256(T) jti=uuid iat exp
+    L->>W: onRequestDPoPSign signingInput=header.payload alg=ES256
+    W->>W: RNSecureKeystoreModule.sign alias=DPoP_ES256 input=signingInput
+    W->>L: sendDPoPSignatureFromJS signature=sig
+    L->>CI: POST /credential Authorization=DPoP T DPoP=header.payload.sig body has openid4vci-proof+jwt
+    CI-->>L: 401 WWW-Authenticate=DPoP error=use_dpop_nonce DPoP-Nonce=nonce-rs-1
+    note over L: Library extracts nonce-rs-1 internally. Wallet never sees this.
+    L->>L: Rebuild proof header+payload with nonce=nonce-rs-1
+    L->>W: onRequestDPoPSign signingInput=new-header.payload alg=ES256
+    W->>W: RNSecureKeystoreModule.sign alias=DPoP_ES256 input=signingInput
+    W->>L: sendDPoPSignatureFromJS signature=sig2
+    L->>CI: POST /credential Authorization=DPoP T DPoP=new-header.payload.sig2 body has openid4vci-proof+jwt
+    CI-->>L: 200 credential issued
+    L-->>W: credential response
+```
+
+---
+
+### Flow 3 — Authorization Code Flow with DPoP
+
+Wallet pre-selects alg for `dpop_jkt` using the same preference logic the library uses, so they agree on the key.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as User Browser
+    participant W as Wallet JS
+    participant L as VCIClient Library
+    participant AS as Authorization Server
+    participant CI as Credential Issuer
+
+    W->>AS: GET /.well-known/oauth-authorization-server
+    AS-->>W: 200 metadata with dpop_signing_alg_values_supported
+    W->>W: Ensure all DPoP key pairs in storage
+    W->>W: Build clientMetadata with dpop.keys list
+    W->>W: Pre-select alg via selectCredentialRequestKey for dpop_jkt
+    W->>W: Compute dpop_jkt = JWK thumbprint of pre-selected DPoP public key
+
+    W->>U: Redirect to AS /authorize with dpop_jkt=jkt and code_challenge=cc
+    note over U,AS: User authenticates. AS records dpop_jkt against the auth code.
+    AS-->>W: 302 redirect with code=auth-code
+    note over W: auth-code is bound to the DPoP key via dpop_jkt
+
+    note over W: Token endpoint — wallet owns this request
+    W->>W: Build DPoP proof-A htm=POST htu=token_endpoint no ath no nonce
+    W->>AS: POST /token DPoP=proof-A grant_type=authorization_code code=auth-code code_verifier=cv redirect_uri=ru
+    AS-->>W: 400 error=use_dpop_nonce DPoP-Nonce=nonce-as-1
+    note over W: Store nonce-as-1 as dpopASNonce
+    W->>W: Build DPoP proof-B with nonce=nonce-as-1
+    W->>AS: POST /token DPoP=proof-B grant_type=authorization_code code=auth-code code_verifier=cv redirect_uri=ru
+    note over AS: AS verifies DPoP public key in proof-B matches dpop_jkt bound to auth-code
+    AS-->>W: 200 access_token=T token_type=DPoP DPoP-Nonce=nonce-as-2
+    note over W: Validate token_type equals DPoP. Store nonce-as-2 as dpopASNonce.
+    W->>L: sendTokenResponse with access_token=T
+
+    note over L,CI: Credential endpoint — library owns this request
+    L->>L: Select alg from clientMetadata.dpop.keys vs AS metadata
+    L->>L: Build proof header+payload htm=POST htu=credential_endpoint ath=SHA256(T) jti=uuid iat exp
+    L->>W: onRequestDPoPSign signingInput=header.payload alg=ES256
+    W->>W: RNSecureKeystoreModule.sign alias=DPoP_ES256 input=signingInput
+    W->>L: sendDPoPSignatureFromJS signature=sig
+    L->>CI: POST /credential Authorization=DPoP T DPoP=header.payload.sig body has openid4vci-proof+jwt
+    CI-->>L: 401 WWW-Authenticate=DPoP error=use_dpop_nonce DPoP-Nonce=nonce-rs-1
+    note over L: Library handles RS nonce internally
+    L->>L: Rebuild proof with nonce=nonce-rs-1
+    L->>W: onRequestDPoPSign signingInput=new-header.payload alg=ES256
+    W->>W: RNSecureKeystoreModule.sign alias=DPoP_ES256 input=signingInput
+    W->>L: sendDPoPSignatureFromJS signature=sig2
+    L->>CI: POST /credential Authorization=DPoP T DPoP=new-header.payload.sig2 body has openid4vci-proof+jwt
+    note over CI: CI verifies cnf.jkt in access token T matches DPoP public key in proof
+    CI-->>L: 200 credential issued
+    L-->>W: credential response
+```
+
+---
+
+### Flow 4 — Token Endpoint DPoP Proof Construction (Wallet JS)
+
+The wallet constructs the full proof for the token endpoint because it owns that HTTP request.
+
+```mermaid
+flowchart TD
+    A([constructDPoPProof called]) --> B[Generate UUID v4 as jti]
+    B --> C[Normalize URL\nstrip query string and fragment as htu]
+    C --> D{dpopASNonce\nin XState context?}
+    D -- Yes --> E[Include nonce claim]
+    D -- No --> F[Omit nonce claim]
+    E --> G[Build JWT payload\njti htm htu iat exp=iat+60 nonce if present\nno ath at token endpoint]
+    F --> G
+    G --> H[Build JWT header\ntyp=dpop+jwt alg=selectedAlg\njwk=selected DPoP public key JWK\nno kid no x5c]
+    H --> I[Sign with RNSecureKeystoreModule\nusing DPoP_selectedAlg alias]
+    I --> J([Return signed dpop+jwt\nadded as DPoP header on token request])
+```
+
+### Flow 5 — Credential Endpoint DPoP Proof Construction (Library)
+
+The library constructs the proof. The wallet only provides the signature.
+
+```mermaid
+flowchart TD
+    A([Library about to call credential endpoint]) --> B[Select alg from clientMetadata.dpop.keys\nvs dpop_signing_alg_values_supported]
+    B --> C[Generate UUID v4 as jti]
+    C --> D[Compute ath = base64url of SHA-256 of access_token]
+    D --> E{RS nonce available\nfrom prior 401?}
+    E -- Yes --> F[Include nonce claim]
+    E -- No --> G[Omit nonce claim]
+    F --> H[Build JWT header+payload\ntyp=dpop+jwt alg htm=POST htu iat exp jti ath\njwk=matching public key from dpop.keys\nnonce if present]
+    G --> H
+    H --> I[fire onRequestDPoPSign\nsigningInput=base64url-header.base64url-payload\nalg=selectedAlg]
+    I --> J[Wallet signs with DPoP_selectedAlg alias]
+    J --> K[Wallet returns base64url signature]
+    K --> L[Library assembles header.payload.signature]
+    L --> M([Set DPoP header and Authorization=DPoP header\nmake credential HTTP request])
+    M --> N{401 use_dpop_nonce?}
+    N -- Yes --> O[Extract DPoP-Nonce from response\nstore internally]
+    O --> C
+    N -- No --> P([Done])
+```
+
+---
+
+### Flow 6 — Nonce Lifecycle
+
+```mermaid
+stateDiagram-v2
+    direction LR
+
+    state "Token Request - Wallet JS" as TR {
+        [*] --> SendProofA : build proof-A no nonce
+        SendProofA --> TokenOK : 200 OK
+        SendProofA --> NonceRequired : 400 use_dpop_nonce
+        NonceRequired --> StoreASNonce : read DPoP-Nonce from error response
+        StoreASNonce --> SendProofB : build proof-B with AS nonce
+        SendProofB --> TokenOK : 200 OK
+        TokenOK --> CheckSuccessNonce : read DPoP-Nonce from 200 response
+        CheckSuccessNonce --> [*] : store as dpopASNonce for next token request
+    }
+
+    state "Credential Request - Library internal" as CR {
+        [*] --> AskWalletSign : fire onRequestDPoPSign no RS nonce yet
+        AskWalletSign --> CredOK : 200 OK
+        AskWalletSign --> RSNonceRequired : 401 use_dpop_nonce
+        RSNonceRequired --> StoreRSNonce : library stores DPoP-Nonce internally
+        StoreRSNonce --> AskWalletSignRetry : fire onRequestDPoPSign with RS nonce in proof
+        AskWalletSignRetry --> CredOK : 200 OK
+        CredOK --> [*] : credential issued
+    }
+
+    [*] --> TR
+    TR --> CR : access token sent to library
+    CR --> [*] : credential issued
+```
+
+---
+
+### Flow 7 — XState Machine State Changes
+
+```mermaid
+stateDiagram-v2
+    direction TB
+
+    [*] --> idle
+
+    state "EXISTING STATES" as existing {
+        idle --> checkingIssuerTrust
+        checkingIssuerTrust --> credentialOfferConsent
+        credentialOfferConsent --> ensuringDPoPKeys
+    }
+
+    state "NEW ensuringDPoPKeys" as ensuringDPoPKeys {
+        [*] --> loadAllKeys : load DPoP_ES256 DPoP_RS256 DPoP_EdDSA DPoP_ES256K from storage
+        loadAllKeys --> generateMissing : generate and store any absent keys
+        generateMissing --> [*] : dpopKeys map in context with all public JWKs
+    }
+
+    ensuringDPoPKeys --> authRedirect : auth code flow\ndpop_jkt appended using pre-selected key
+    ensuringDPoPKeys --> tokenRequest : pre-auth flow
+
+    authRedirect --> waitingForAuthCode
+    waitingForAuthCode --> tokenRequest : auth code received
+
+    state "MODIFIED tokenRequest" as tokenRequest {
+        [*] --> sendWithDPoP : sendTokenRequest with DPoP header\nusing pre-selected alg + dpopASNonce
+        sendWithDPoP --> tokenOK : 200 DPoP token
+        sendWithDPoP --> nonceError : 400 use_dpop_nonce
+    }
+
+    state "NEW retryTokenWithNonce" as retryNonce {
+        [*] --> storeNonce : store dpopASNonce from 400 response
+        storeNonce --> retry : sendTokenRequest again with nonce in proof
+        retry --> [*] : 200 DPoP token
+    }
+
+    tokenRequest --> retryNonce : use_dpop_nonce error
+    tokenRequest --> sendTokenResponse : success
+    retryNonce --> sendTokenResponse : success
+
+    sendTokenResponse --> idle : token and clientMetadata delivered to library
+
+    idle --> constructProof : onRequestProof event
+    constructProof --> idle : openid4vci-proof+jwt sent
+
+    state "NEW signingDPoP" as signingDPoP {
+        [*] --> sign : RNSecureKeystoreModule.sign\nalias=DPoP_alg from event\ninput=signingInput from event
+        sign --> [*] : sendDPoPSignatureFromJS
+    }
+
+    idle --> signingDPoP : onRequestDPoPSign event from library
+    signingDPoP --> idle
+```
+
+---
+
+## Key Separation
+
+```mermaid
+graph LR
+    DPoP["DPoP Keys\nDPoP_ES256 DPoP_RS256\nDPoP_EdDSA DPoP_ES256K"] --> T["Token endpoint DPoP proof\nCredential endpoint DPoP proof"]
+    Proof["Credential Proof Key\nOpenId4VCI_KeyPair"] --> P["openid4vci-proof+jwt\nin credential request body"]
+```
+
+---
+
+## Consequences
+
+### Positive
+
+- Access tokens are sender-constrained — a stolen token is useless without the DPoP private key.
+- All four wallet key types (ES256, RS256, EdDSA, ES256K) are available for DPoP — interoperable with any AS regardless of which alg it supports.
+- Library handles RS nonce and retry loop — wallet has no RS nonce state to manage.
+- No new native method parameters — DPoP config travels inside the existing `clientMetadata` JSON.
+- Compatible with ASes enforcing `dpop_bound_access_tokens: true`.
+- `dpop_jkt` binding prevents auth code injection (read: RFC 9449 §11.9).
+- Nonce support prevents proof pre-generation (read: RFC 9449 §11.2).
+
+### Trade-offs
+
+- **`ensuringDPoPKeys` generates up to four key pairs on first run.** Subsequent flows load from storage — cost is one-time.
+- **dpop_jkt alg coordination is implicit.** Wallet and library independently apply the same preference order to the same key list and AS metadata — they must agree. Any divergence in preference order between wallet and library would cause a mismatch.
+- **VCIClient library requires changes.** `ClientMetadata.dpop`, `signDPoP` closure, and internal RS nonce handling must be added upstream.
+
+### Non-goals
+
+- DPoP for VP presentation flows (OpenID4VP) — out of scope.
+- DPoP for the wallet binding (WLA) endpoint — separate flow.
+- Refresh token DPoP binding — wallet does not use refresh tokens in OID4VCI flows today.

--- a/ios/Inji.xcodeproj/project.pbxproj
+++ b/ios/Inji.xcodeproj/project.pbxproj
@@ -1207,7 +1207,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/inji/inji-vci-client-ios-swift";
 			requirement = {
-				branch = develop;
+				branch = "feat/dpop";
 				kind = branch;
 			};
 		};

--- a/ios/Inji.xcodeproj/project.pbxproj
+++ b/ios/Inji.xcodeproj/project.pbxproj
@@ -1207,7 +1207,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/inji/inji-vci-client-ios-swift";
 			requirement = {
-				branch = "feat/dpop";
+				branch = develop;
 				kind = branch;
 			};
 		};

--- a/ios/Inji.xcodeproj/project.pbxproj
+++ b/ios/Inji.xcodeproj/project.pbxproj
@@ -1059,7 +1059,10 @@
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1123,7 +1126,10 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/inji/inji-vci-client-ios-swift",
       "state" : {
-        "branch" : "develop",
-        "revision" : "90b31310f555ac05879c9c09a1dac3c3fa41f71b"
+        "branch" : "feat/dpop",
+        "revision" : "26f89be254161d2e5f2b7bcbbc62070d6bdc6fd8"
       }
     },
     {

--- a/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/inji/inji-vci-client-ios-swift",
       "state" : {
-        "branch" : "feat/dpop",
-        "revision" : "26f89be254161d2e5f2b7bcbbc62070d6bdc6fd8"
+        "branch" : "develop",
+        "revision" : "90b31310f555ac05879c9c09a1dac3c3fa41f71b"
       }
     },
     {

--- a/ios/Inji/Info.plist
+++ b/ios/Inji/Info.plist
@@ -92,6 +92,8 @@
 		<string>Feather.ttf</string>
 		<string>AntDesign.ttf</string>
 	</array>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>SplashScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -118,7 +120,5 @@
 	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>UIDesignRequiresCompatibility</key>
-	<true/>
 </dict>
 </plist>

--- a/ios/RNVCIClientModule.m
+++ b/ios/RNVCIClientModule.m
@@ -26,6 +26,11 @@ RCT_EXTERN_METHOD(getIssuerMetadata:(NSString *)credentialIssuer
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+// Generates a fresh token-endpoint DPoP proof bound to the supplied nonce (use_dpop_nonce retry)
+RCT_EXTERN_METHOD(generateTokenDPoPProof:(NSString *)dpopNonce
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 // Sends proof JWT back to native side (in response to onRequestProof)
 RCT_EXTERN_METHOD(sendProofFromJS:(NSString *)jwtProof)
 

--- a/ios/RNVCIClientModule.swift
+++ b/ios/RNVCIClientModule.swift
@@ -220,6 +220,23 @@ class RNVCIClientModule: NSObject, RCTBridgeModule {
     }
   }
 
+  @objc
+  func generateTokenDPoPProof(
+    _ dpopNonce: String,
+    resolver resolve: @escaping RCTPromiseResolveBlock,
+    rejecter reject: @escaping RCTPromiseRejectBlock
+  ) {
+    do {
+      guard let vciClient = vciClient else {
+        reject(nil, "VCIClient not initialized", nil)
+        return
+      }
+      resolve(try vciClient.generateTokenDPoPProof(dpopNonce: dpopNonce))
+    } catch {
+      reject(nil, error.localizedDescription, nil)
+    }
+  }
+
   // MARK: - Callbacks to JS
 
   private func getTxCodeHook(
@@ -358,6 +375,7 @@ class RNVCIClientModule: NSObject, RCTBridgeModule {
         "clientId": tokenRequest.clientId ?? NSNull(),
         "redirectUri": tokenRequest.redirectUri ?? NSNull(),
         "codeVerifier": tokenRequest.codeVerifier ?? NSNull(),
+        "dpopProof": tokenRequest.dpopProof ?? NSNull(),
       ]
 
       bridge.eventDispatcher().sendAppEvent(

--- a/machines/Issuers/IssuersService.ts
+++ b/machines/Issuers/IssuersService.ts
@@ -15,6 +15,7 @@ import {
 import VciClient, {
   VciClientErrorResponse,
 } from '../../shared/vciClient/VciClient';
+import {sendTokenRequest} from '../../shared/openId4VCI/sendTokenRequest';
 import {displayType, issuerType} from './IssuersMachine';
 import {setItem} from '../store';
 import {
@@ -394,68 +395,3 @@ export const IssuersService = () => {
     },
   };
 };
-async function sendTokenRequest(
-  tokenRequestObject: any,
-  proxyTokenEndpoint: any = null,
-) {
-  if (proxyTokenEndpoint) {
-    tokenRequestObject.tokenEndpoint = proxyTokenEndpoint;
-  }
-  if (!tokenRequestObject?.tokenEndpoint) {
-    console.error('tokenEndpoint is not provided in tokenRequestObject');
-    throw new Error('tokenEndpoint is required');
-  }
-
-  const formBody = new URLSearchParams();
-
-  formBody.append('grant_type', tokenRequestObject.grantType);
-
-  if (tokenRequestObject.authCode) {
-    formBody.append('code', tokenRequestObject.authCode);
-  }
-  if (tokenRequestObject.preAuthCode) {
-    formBody.append('pre-authorized_code', tokenRequestObject.preAuthCode);
-  }
-  if (tokenRequestObject.txCode) {
-    formBody.append('tx_code', tokenRequestObject.txCode);
-  }
-  if (tokenRequestObject.clientId) {
-    formBody.append('client_id', tokenRequestObject.clientId);
-  }
-  if (tokenRequestObject.redirectUri) {
-    formBody.append('redirect_uri', tokenRequestObject.redirectUri);
-  }
-  if (tokenRequestObject.codeVerifier) {
-    formBody.append('code_verifier', tokenRequestObject.codeVerifier);
-  }
-  const response = await fetch(tokenRequestObject.tokenEndpoint, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: formBody.toString(),
-  });
-
-  if (!response.ok) {
-    const errorText = await response.text();
-    console.error(
-      'Token request failed with status:',
-      response.status,
-      errorText,
-    );
-    let parsedError: any;
-    try {
-      parsedError = JSON.parse(errorText);
-    } catch {
-      parsedError = {};
-    }
-    //have to throw error in vci error response format
-    const errorResponse: VciClientErrorResponse = {
-      serverErrorCode: parsedError.error ?? 'UNKNOWN_ERROR',
-      serverErrorMessage: parsedError.error_description,
-    };
-    throw errorResponse;
-  }
-  const tokenResponse = await response.json();
-  return tokenResponse;
-}

--- a/shared/openId4VCI/sendTokenRequest.test.ts
+++ b/shared/openId4VCI/sendTokenRequest.test.ts
@@ -1,0 +1,163 @@
+const mockGenerateTokenDPoPProof = jest.fn();
+
+jest.mock('../vciClient/VciClient', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({
+      generateTokenDPoPProof: mockGenerateTokenDPoPProof,
+    }),
+  },
+}));
+
+import {sendTokenRequest} from './sendTokenRequest';
+
+type FakeResponseOptions = {
+  ok: boolean;
+  status?: number;
+  body?: string;
+  nonce?: string;
+};
+
+function fakeResponse({
+  ok,
+  status = 200,
+  body = '{}',
+  nonce,
+}: FakeResponseOptions) {
+  return {
+    ok,
+    status,
+    text: async () => body,
+    json: async () => JSON.parse(body),
+    headers: {
+      get: (header: string) => (header === 'DPoP-Nonce' ? nonce ?? null : null),
+    },
+  } as any;
+}
+
+describe('sendTokenRequest', () => {
+  const baseRequest = {
+    grantType: 'authorization_code',
+    tokenEndpoint: 'https://as.example.com/token',
+    authCode: 'auth-code',
+    codeVerifier: 'verifier',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  it('attaches the DPoP header when dpopProof is present', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      fakeResponse({
+        ok: true,
+        body: '{"access_token":"t","token_type":"DPoP"}',
+      }),
+    );
+
+    const result = await sendTokenRequest({
+      ...baseRequest,
+      dpopProof: 'proof-a',
+    });
+
+    expect(result.access_token).toBe('t');
+    const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(options.headers.DPoP).toBe('proof-a');
+  });
+
+  it('does not attach the DPoP header when dpopProof is absent', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      fakeResponse({
+        ok: true,
+        body: '{"access_token":"t","token_type":"Bearer"}',
+      }),
+    );
+
+    await sendTokenRequest({...baseRequest});
+
+    const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(options.headers.DPoP).toBeUndefined();
+  });
+
+  it('retries with a fresh proof on a use_dpop_nonce challenge', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        fakeResponse({
+          ok: false,
+          status: 400,
+          body: '{"error":"use_dpop_nonce"}',
+          nonce: 'server-nonce',
+        }),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({
+          ok: true,
+          body: '{"access_token":"t","token_type":"DPoP"}',
+        }),
+      );
+    mockGenerateTokenDPoPProof.mockResolvedValueOnce('proof-b');
+
+    const result = await sendTokenRequest({
+      ...baseRequest,
+      dpopProof: 'proof-a',
+    });
+
+    expect(result.access_token).toBe('t');
+    expect(mockGenerateTokenDPoPProof).toHaveBeenCalledWith('server-nonce');
+    expect((global.fetch as jest.Mock).mock.calls).toHaveLength(2);
+    const [, firstOptions] = (global.fetch as jest.Mock).mock.calls[0];
+    const [, retryOptions] = (global.fetch as jest.Mock).mock.calls[1];
+    expect(firstOptions.headers.DPoP).toBe('proof-a');
+    expect(retryOptions.headers.DPoP).toBe('proof-b');
+  });
+
+  it('throws when the retry after a nonce challenge also fails', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        fakeResponse({
+          ok: false,
+          status: 400,
+          body: '{"error":"use_dpop_nonce"}',
+          nonce: 'server-nonce',
+        }),
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({ok: false, status: 400, body: 'still failing'}),
+      );
+    mockGenerateTokenDPoPProof.mockResolvedValueOnce('proof-b');
+
+    await expect(
+      sendTokenRequest({...baseRequest, dpopProof: 'proof-a'}),
+    ).rejects.toThrow('Token request failed: 400 still failing');
+  });
+
+  it('does not retry for non use_dpop_nonce errors', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      fakeResponse({ok: false, status: 400, body: '{"error":"invalid_grant"}'}),
+    );
+
+    await expect(
+      sendTokenRequest({...baseRequest, dpopProof: 'proof-a'}),
+    ).rejects.toThrow('Token request failed: 400');
+    expect(mockGenerateTokenDPoPProof).not.toHaveBeenCalled();
+    expect((global.fetch as jest.Mock).mock.calls).toHaveLength(1);
+  });
+
+  it('uses the proxy token endpoint when provided', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      fakeResponse({ok: true, body: '{"access_token":"t"}'}),
+    );
+
+    await sendTokenRequest({...baseRequest}, 'https://proxy.example.com/token');
+
+    const [url] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('https://proxy.example.com/token');
+  });
+
+  it('throws when tokenEndpoint is missing', async () => {
+    await expect(
+      sendTokenRequest({grantType: 'authorization_code'}),
+    ).rejects.toThrow('tokenEndpoint is required');
+  });
+});

--- a/shared/openId4VCI/sendTokenRequest.ts
+++ b/shared/openId4VCI/sendTokenRequest.ts
@@ -1,0 +1,123 @@
+import VciClient from '../vciClient/VciClient';
+
+const USE_DPOP_NONCE_ERROR = 'use_dpop_nonce';
+const DPOP_HEADER = 'DPoP';
+const DPOP_NONCE_HEADER = 'DPoP-Nonce';
+
+function buildTokenFormBody(tokenRequestObject: any): URLSearchParams {
+  const formBody = new URLSearchParams();
+  formBody.append('grant_type', tokenRequestObject.grantType);
+
+  if (tokenRequestObject.authCode) {
+    formBody.append('code', tokenRequestObject.authCode);
+  }
+  if (tokenRequestObject.preAuthCode) {
+    formBody.append('pre-authorized_code', tokenRequestObject.preAuthCode);
+  }
+  if (tokenRequestObject.txCode) {
+    formBody.append('tx_code', tokenRequestObject.txCode);
+  }
+  if (tokenRequestObject.clientId) {
+    formBody.append('client_id', tokenRequestObject.clientId);
+  }
+  if (tokenRequestObject.redirectUri) {
+    formBody.append('redirect_uri', tokenRequestObject.redirectUri);
+  }
+  if (tokenRequestObject.codeVerifier) {
+    formBody.append('code_verifier', tokenRequestObject.codeVerifier);
+  }
+  return formBody;
+}
+
+async function postTokenRequest(
+  tokenEndpoint: string,
+  formBody: URLSearchParams,
+  dpopProof?: string | null,
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+  };
+  if (dpopProof) {
+    headers[DPOP_HEADER] = dpopProof;
+  }
+  return await fetch(tokenEndpoint, {
+    method: 'POST',
+    headers,
+    body: formBody.toString(),
+  });
+}
+
+function isUseDpopNonceError(errorBody: string): boolean {
+  try {
+    return JSON.parse(errorBody)?.error === USE_DPOP_NONCE_ERROR;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Performs the OID4VCI token request. The DPoP proof is built and signed by the VCIClient
+ * library and arrives on `tokenRequestObject.dpopProof`; the wallet only attaches it as the
+ * `DPoP` header. On an authorization server `use_dpop_nonce` challenge the wallet asks the
+ * library for a fresh proof bound to the supplied nonce and retries once (RFC 9449).
+ */
+export async function sendTokenRequest(
+  tokenRequestObject: any,
+  proxyTokenEndpoint: any = null,
+) {
+  if (proxyTokenEndpoint) {
+    tokenRequestObject.tokenEndpoint = proxyTokenEndpoint;
+  }
+  if (!tokenRequestObject?.tokenEndpoint) {
+    console.error('tokenEndpoint is not provided in tokenRequestObject');
+    throw new Error('tokenEndpoint is required');
+  }
+
+  const formBody = buildTokenFormBody(tokenRequestObject);
+
+  let response = await postTokenRequest(
+    tokenRequestObject.tokenEndpoint,
+    formBody,
+    tokenRequestObject.dpopProof,
+  );
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    const dpopNonce = response.headers?.get(DPOP_NONCE_HEADER);
+
+    if (
+      response.status === 400 &&
+      isUseDpopNonceError(errorBody) &&
+      dpopNonce
+    ) {
+      const refreshedProof =
+        await VciClient.getInstance().generateTokenDPoPProof(dpopNonce);
+      response = await postTokenRequest(
+        tokenRequestObject.tokenEndpoint,
+        formBody,
+        refreshedProof,
+      );
+
+      if (!response.ok) {
+        const retryError = await response.text();
+        console.error(
+          'Token request failed after DPoP nonce retry with status:',
+          response.status,
+          retryError,
+        );
+        throw new Error(
+          `Token request failed: ${response.status} ${retryError}`,
+        );
+      }
+    } else {
+      console.error(
+        'Token request failed with status:',
+        response.status,
+        errorBody,
+      );
+      throw new Error(`Token request failed: ${response.status} ${errorBody}`);
+    }
+  }
+
+  return await response.json();
+}

--- a/shared/vciClient/VciClient.ts
+++ b/shared/vciClient/VciClient.ts
@@ -4,7 +4,10 @@ import {
   SelectedCredentialsForVPSharing,
   VerifiableCredential,
 } from '../../machines/VerifiableCredential/VCMetaMachine/vc';
-import {getWalletConfig, jsonLdCanonicalize} from '../openID4VP/OpenID4VPHelper';
+import {
+  getWalletConfig,
+  jsonLdCanonicalize,
+} from '../openID4VP/OpenID4VPHelper';
 
 const emitter = new NativeEventEmitter(NativeModules.InjiVciClient);
 
@@ -76,6 +79,10 @@ class VciClient {
 
   async sendTokenResponse(json: string) {
     this.InjiVciClient.sendTokenResponseFromJS(json);
+  }
+
+  async generateTokenDPoPProof(dpopNonce: string): Promise<string> {
+    return await this.InjiVciClient.generateTokenDPoPProof(dpopNonce);
   }
 
   async getIssuerMetadata(issuerUri: string): Promise<object> {
@@ -165,11 +172,11 @@ class VciClient {
         clientId: 'wallet',
         redirectUri: 'io.mosip.residentapp.inji://oauthredirect',
       };
-      const openId4VpWalletConfig = await getWalletConfig()
+      const openId4VpWalletConfig = await getWalletConfig();
       response = await this.InjiVciClient.requestCredentialByOffer(
         credentialOffer,
         JSON.stringify(clientMetadata),
-        openId4VpWalletConfig
+        openId4VpWalletConfig,
       );
     } catch (error) {
       console.error('Error requesting credential by offer:', error);
@@ -258,12 +265,12 @@ class VciClient {
 
     let response = '';
     try {
-      const openId4VpWalletConfig = await getWalletConfig()
+      const openId4VpWalletConfig = await getWalletConfig();
       response = await this.InjiVciClient.requestCredentialFromTrustedIssuer(
         credentialIssuerUri,
         credentialConfigurationId,
         JSON.stringify(clientMetadata),
-        openId4VpWalletConfig
+        openId4VpWalletConfig,
       );
     } catch (error) {
       console.error('Error requesting credential from trusted issuer:', error);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an Architecture Decision Record for OID4VCI sender-constrained access-token handling using DPoP (RFC 9449), including per-flow proof behavior and nonce retry flow updates.
* **New Features**
  * Exposed a new API to generate fresh token-endpoint DPoP proofs from a provided nonce.
  * Extended token-request handling to include DPoP proofs and support nonce-driven retry when required.
* **Bug Fixes**
  * Standardized token endpoint requests through a shared implementation, improving DPoP header and retry correctness.
* **Tests**
  * Added Jest coverage for token-request DPoP behavior, including nonce retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->