### PR TITLE
refactor: align vci client error fields with issuer error naming

### DIFF
--- a/android/app/src/main/java/io/mosip/residentapp/BinarySigner.kt
+++ b/android/app/src/main/java/io/mosip/residentapp/BinarySigner.kt
@@ -30,7 +30,7 @@ object BinarySigner {
                 val action: (CryptoObject) -> Unit = { cryptoObject ->
                     val signature = cryptoObject.signature!!
                     signature.update(payload)
-                    onSuccess(Base64.encodeToString(signature.sign(), Base64.URL_SAFE))
+                    onSuccess(Base64.encodeToString(signature.sign(), Base64.NO_WRAP))
                 }
                 biometrics.authenticateAndPerform(createCryptoObject, action, onFailure, context)
             }

--- a/android/app/src/main/java/io/mosip/residentapp/InjiVciClientModule.java
+++ b/android/app/src/main/java/io/mosip/residentapp/InjiVciClientModule.java
@@ -179,16 +179,12 @@ public class InjiVciClientModule extends ReactContextBaseJavaModule {
 
       WritableMap userInfo = Arguments.createMap();
 
-      if (ex.getSourceErrorCode() != null) {
-        userInfo.putString("sourceErrorCode", ex.getSourceErrorCode());
+      if (ex.getIssuerErrorCode() != null) {
+        userInfo.putString("issuerErrorCode", ex.getIssuerErrorCode());
       }
 
-      if (ex.getServerErrorCode() != null) {
-        userInfo.putString("serverErrorCode", ex.getServerErrorCode());
-      }
-
-      if (ex.getServerErrorDescription() != null) {
-        userInfo.putString("serverErrorDescription", ex.getServerErrorDescription());
+      if (ex.getIssuerErrorDescription() != null) {
+        userInfo.putString("issuerErrorDescription", ex.getIssuerErrorDescription());
       }
 
       promise.reject(

--- a/components/ui/Error.tsx
+++ b/components/ui/Error.tsx
@@ -1,19 +1,19 @@
-import { useFocusEffect } from '@react-navigation/native';
-import React, { Fragment, useEffect, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { BackHandler, Dimensions, ScrollView, View } from 'react-native';
-import { ButtonProps as RNEButtonProps } from 'react-native-elements';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Button, Column, Row, Text } from '.';
-import { Header } from './Header';
-import { Theme } from './styleUtils';
+import {useFocusEffect} from '@react-navigation/native';
+import React, {Fragment, useEffect, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import {BackHandler, Dimensions, ScrollView, View} from 'react-native';
+import {ButtonProps as RNEButtonProps} from 'react-native-elements';
+import {useSafeAreaInsets} from 'react-native-safe-area-context';
+import {Button, Column, Row, Text} from '.';
+import {Header} from './Header';
+import {Theme} from './styleUtils';
 import testIDProps from '../../shared/commonUtil';
-import { Modal } from './Modal';
-import { isIOS } from '../../shared/constants';
-import { BackButton } from './backButton/BackButton';
+import {Modal} from './Modal';
+import {isIOS} from '../../shared/constants';
+import {BackButton} from './backButton/BackButton';
 
 export const ErrorView: React.FC<ErrorProps> = props => {
-  const { t } = useTranslation('common');
+  const {t} = useTranslation('common');
   const insets = useSafeAreaInsets();
   const {
     testID,
@@ -70,13 +70,13 @@ export const ErrorView: React.FC<ErrorProps> = props => {
     const compactHeader = !!additionalContent;
 
     const headerSection = (
-      <View style={[{ alignItems: 'center', marginHorizontal: 1 }, customStyles]}>
+      <View style={[{alignItems: 'center', marginHorizontal: 1}, customStyles]}>
         <Row
           align="center"
           style={[
             Theme.ErrorStyles.image,
             customImageStyles,
-            compactHeader ? { paddingBottom: 10, marginTop: -20 } : undefined,
+            compactHeader ? {paddingBottom: 10, marginTop: -20} : undefined,
           ]}>
           {image}
         </Row>
@@ -89,8 +89,8 @@ export const ErrorView: React.FC<ErrorProps> = props => {
     const buttonsSection = (
       <Column
         crossAlign="center"
-        style={{ paddingBottom: Math.max(insets.bottom, isIOS() ? 30 : 20) }}>
-        <Row style={{ marginHorizontal: 30, marginBottom: 15 }}>
+        style={{paddingBottom: Math.max(insets.bottom, isIOS() ? 30 : 20)}}>
+        <Row style={{marginHorizontal: 30, marginBottom: 15}}>
           {primaryButtonText && (
             <Button
               fill
@@ -102,7 +102,7 @@ export const ErrorView: React.FC<ErrorProps> = props => {
           )}
         </Row>
         {textButtonType === 'gradient' ? (
-          <Row style={{ marginHorizontal: 30 }}>
+          <Row style={{marginHorizontal: 30}}>
             {textButtonText && (
               <Button
                 fill
@@ -133,31 +133,26 @@ export const ErrorView: React.FC<ErrorProps> = props => {
         <Fragment>
           <ScrollView>
             {headerSection}
-            {additionalContent ? (
-              <View
-                style={{ flex: 1 }}>
-                <View style={{ alignItems: 'center' }}>
+            <View style={{flex: 1}}>
+              <View style={{alignItems: 'center'}}>
+                <Text
+                  style={[
+                    Theme.ErrorStyles.message,
+                    compactHeader ? {marginBottom: 10} : undefined,
+                  ]}
+                  testID={`${testID}Message`}>
+                  {message}
+                </Text>
+                {additionalMessage && (
                   <Text
-                    style={[
-                      Theme.ErrorStyles.message,
-                      compactHeader ? { marginBottom: 10 } : undefined,
-                    ]}
-                    testID={`${testID}Message`}>
-                    {message}
+                    style={Theme.ErrorStyles.additionalMessage}
+                    testID={`${testID}AdditionalMessage`}>
+                    {additionalMessage}
                   </Text>
-                  {additionalMessage && (
-                    <Text
-                      style={Theme.ErrorStyles.additionalMessage}
-                      testID={`${testID}AdditionalMessage`}>
-                      {additionalMessage}
-                    </Text>
-                  )}
-                </View>
-                {additionalContent}
+                )}
               </View>
-            ) : (
-              <View style={{ flex: 1 }} />
-            )}
+              {additionalContent}
+            </View>
           </ScrollView>
           {buttonsSection}
         </Fragment>
@@ -167,7 +162,7 @@ export const ErrorView: React.FC<ErrorProps> = props => {
     return (
       <Fragment>
         <View
-          style={[{ alignItems: 'center', marginHorizontal: 1 }, customStyles]}>
+          style={[{alignItems: 'center', marginHorizontal: 1}, customStyles]}>
           <View>
             <Row
               align="center"
@@ -189,7 +184,7 @@ export const ErrorView: React.FC<ErrorProps> = props => {
             )}
           </View>
           {additionalContent}
-          <View style={{ paddingBottom: insets.bottom, alignItems: 'center' }}>
+          <View style={{paddingBottom: insets.bottom, alignItems: 'center'}}>
             {primaryButtonText && (
               <Button
                 onPress={primaryButtonEvent}

--- a/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -97,7 +97,7 @@
       "location" : "https://github.com/inji/inji-vci-client-ios-swift",
       "state" : {
         "branch" : "develop",
-        "revision" : "90b31310f555ac05879c9c09a1dac3c3fa41f71b"
+        "revision" : "1c3c610ad725397aaccb6bbf0cf71a719b61a71c"
       }
     },
     {

--- a/ios/RNVCIClientModule.swift
+++ b/ios/RNVCIClientModule.swift
@@ -188,16 +188,12 @@ class RNVCIClientModule: NSObject, RCTBridgeModule {
         "code": vciError.code
       ]
 
-      if let sourceErrorCode = vciError.sourceErrorCode {
-        userInfo["sourceErrorCode"] = sourceErrorCode
+      if let issuerErrorCode = vciError.issuerErrorCode {
+        userInfo["issuerErrorCode"] = issuerErrorCode
       }
 
-      if let serverErrorCode = vciError.serverErrorCode {
-        userInfo["serverErrorCode"] = serverErrorCode
-      }
-
-      if let serverErrorDescription = vciError.serverErrorDescription {
-        userInfo["serverErrorDescription"] = serverErrorDescription
+      if let issuerErrorDescription = vciError.issuerErrorDescription {
+        userInfo["issuerErrorDescription"] = issuerErrorDescription
       }
 
       let nsError = NSError(
@@ -400,7 +396,7 @@ class RNVCIClientModule: NSObject, RCTBridgeModule {
     _ response: CredentialResponse
   ) throws -> String {
     guard let firstItem = response.credentials?.first else {
-      throw VCIClientException(code: "DOWNLOAD_FAILED", message: "No credential returned from issuer", serverErrorCode: nil, serverErrorDescription: nil)
+      throw VCIClientException(code: "DOWNLOAD_FAILED", message: "No credential returned from issuer", issuerErrorCode: nil, issuerErrorDescription: nil)
     }
 
     var dict: [String: Any] = [

--- a/machines/Issuers/IssuersActions.test.ts
+++ b/machines/Issuers/IssuersActions.test.ts
@@ -19,6 +19,8 @@ jest.mock('../../shared/openId4VCI/Utils', () => ({
   VCIServerErrorCode: {
     SERVER_ERROR: 'server_error',
     INVALID_CREDENTIAL_OFFER: 'invalid_credential_offer',
+    TIMEOUT_ERROR: 'timeout_error',
+    UNSUPPORTED_GRANT_TYPE: 'unsupported_grant_type',
     UNKNOWN_ERROR: 'unknown_error',
   },
   OIDCErrors: {
@@ -386,6 +388,18 @@ describe('IssuersActions', () => {
           {data: {issuerErrorCode: 'unsupported_grant_type'}},
         ),
       ).toBe('unsupported_grant_type');
+      consoleSpy.mockRestore();
+    });
+
+    it('setError falls back to server error for an unmapped issuer error code', () => {
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const fn = actions.setError.assignment.errorMessage;
+      expect(
+        fn(
+          {isInternetAvailable: true},
+          {data: {issuerErrorCode: 'some_unmapped_issuer_error'}},
+        ),
+      ).toBe('server_error');
       consoleSpy.mockRestore();
     });
 

--- a/machines/Issuers/IssuersActions.test.ts
+++ b/machines/Issuers/IssuersActions.test.ts
@@ -306,10 +306,11 @@ describe('IssuersActions', () => {
       expect(actions.resetLoadingReason.assignment.loadingReason).toBeNull();
     });
 
-    it('resetAuthorization resets auth type and success', () => {
+    it('resetAuthorization resets auth type, success and auth endpoint flag', () => {
       const asg = actions.resetAuthorization.assignment;
       expect(asg.authorizationType).toBe('implicit');
       expect(asg.authorizationSuccess).toBe(false);
+      expect(asg.authEndpointToOpen).toBe(false);
     });
 
     it('setSelectedCredentialType picks credType and wellknown key types', () => {

--- a/machines/Issuers/IssuersActions.test.ts
+++ b/machines/Issuers/IssuersActions.test.ts
@@ -371,9 +371,9 @@ describe('IssuersActions', () => {
     it('setError returns invalid credential offer for VCI-008 source error', () => {
       const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
       const fn = actions.setError.assignment.errorMessage;
-      expect(
-        fn({isInternetAvailable: true}, {data: {sourceErrorCode: 'VCI-008'}}),
-      ).toBe('invalid_credential_offer');
+      expect(fn({isInternetAvailable: true}, {data: {code: 'VCI-008'}})).toBe(
+        'invalid_credential_offer',
+      );
       consoleSpy.mockRestore();
     });
 
@@ -383,7 +383,7 @@ describe('IssuersActions', () => {
       expect(
         fn(
           {isInternetAvailable: true},
-          {data: {serverErrorCode: 'unsupported_grant_type'}},
+          {data: {issuerErrorCode: 'unsupported_grant_type'}},
         ),
       ).toBe('unsupported_grant_type');
       consoleSpy.mockRestore();

--- a/machines/Issuers/IssuersActions.ts
+++ b/machines/Issuers/IssuersActions.ts
@@ -125,13 +125,13 @@ export const IssuersActions = (model: any) => {
       errorMessage: (context: any, event: any) => {
         const error = (event.data ?? event) as VciClientErrorResponse;
         console.error(`Error occurred while ${event} -> `, error);
-        if (error.serverErrorCode)
-          return error.serverErrorCode as VCIServerErrorCode;
+        if (error.issuerErrorCode)
+          return error.issuerErrorCode as VCIServerErrorCode;
         if (!context.isInternetAvailable) {
           return ErrorMessage.NO_INTERNET;
-        } else if (error.sourceErrorCode === 'VCI-008') {
+        } else if (error.code === 'VCI-008') {
           return VCIServerErrorCode.INVALID_CREDENTIAL_OFFER;
-        } else if (error.sourceErrorCode === 'VCI-007') {
+        } else if (error.code === 'VCI-007') {
           return VCIServerErrorCode.TIMEOUT_ERROR;
         } else if (error.code) return VCIServerErrorCode.SERVER_ERROR;
         else return VCIServerErrorCode.UNKNOWN_ERROR;

--- a/machines/Issuers/IssuersActions.ts
+++ b/machines/Issuers/IssuersActions.ts
@@ -82,6 +82,7 @@ export const IssuersActions = (model: any) => {
     resetAuthorization: model.assign({
       authorizationType: AuthorizationType.IMPLICIT,
       authorizationSuccess: false,
+      authEndpointToOpen: false,
     }),
     setSelectedCredentialType: model.assign({
       selectedCredentialType: (_: any, event: any) => event.credType,

--- a/machines/Issuers/IssuersActions.ts
+++ b/machines/Issuers/IssuersActions.ts
@@ -125,8 +125,14 @@ export const IssuersActions = (model: any) => {
       errorMessage: (context: any, event: any) => {
         const error = (event.data ?? event) as VciClientErrorResponse;
         console.error(`Error occurred while ${event} -> `, error);
-        if (error.issuerErrorCode)
-          return error.issuerErrorCode as VCIServerErrorCode;
+        if (error.issuerErrorCode) {
+          const isMappedIssuerError = Object.values(
+            VCIServerErrorCode,
+          ).includes(error.issuerErrorCode as VCIServerErrorCode);
+          return isMappedIssuerError
+            ? (error.issuerErrorCode as VCIServerErrorCode)
+            : VCIServerErrorCode.SERVER_ERROR;
+        }
         if (!context.isInternetAvailable) {
           return ErrorMessage.NO_INTERNET;
         } else if (error.code === 'VCI-008') {

--- a/machines/Issuers/IssuersEvents.ts
+++ b/machines/Issuers/IssuersEvents.ts
@@ -11,11 +11,11 @@ export const IssuersEvents = {
   SHOW_ERROR: (error: any) => ({error}),
   CHECK_KEY_PAIR: () => ({}),
   CANCEL: (
-    {serverErrorCode, serverErrorDescription} = {} as {
-      serverErrorCode?: string;
-      serverErrorDescription?: string;
+    {issuerErrorCode, issuerErrorDescription} = {} as {
+      issuerErrorCode?: string;
+      issuerErrorDescription?: string;
     },
-  ) => ({serverErrorCode, serverErrorDescription}),
+  ) => ({issuerErrorCode, issuerErrorDescription}),
   STORE_RESPONSE: (response?: unknown) => ({response}),
   STORE_ERROR: (error: Error, requester?: string) => ({error, requester}),
   RESET_VERIFY_ERROR: () => ({}),

--- a/machines/Issuers/IssuersService.test.ts
+++ b/machines/Issuers/IssuersService.test.ts
@@ -460,8 +460,8 @@ describe('IssuersService', () => {
       authorizationType: 'other',
     };
     await expect(services.sendTokenRequest(context)).rejects.toMatchObject({
-      serverErrorCode: 'invalid_request',
-      serverErrorMessage: 'Bad Request',
+      issuerErrorCode: 'invalid_request',
+      issuerErrorMessage: 'Bad Request',
     });
   });
 

--- a/machines/Issuers/IssuersService.ts
+++ b/machines/Issuers/IssuersService.ts
@@ -451,8 +451,8 @@ async function sendTokenRequest(
     }
     //have to throw error in vci error response format
     const errorResponse: VciClientErrorResponse = {
-      serverErrorCode: parsedError.error ?? 'UNKNOWN_ERROR',
-      serverErrorMessage: parsedError.error_description,
+      issuerErrorCode: parsedError.error ?? 'UNKNOWN_ERROR',
+      issuerErrorMessage: parsedError.error_description,
     };
     throw errorResponse;
   }

--- a/screens/AuthWebViewScreen.tsx
+++ b/screens/AuthWebViewScreen.tsx
@@ -107,8 +107,8 @@ const AuthWebViewScreen: React.FC<any> = ({route, navigation}) => {
 
         if (error) {
           controller.CANCEL({
-            serverErrorCode: error,
-            serverErrorDescription: errorDescription,
+            issuerErrorCode: error,
+            issuerErrorDescription: errorDescription,
           });
 
           navigation.goBack();
@@ -117,8 +117,8 @@ const AuthWebViewScreen: React.FC<any> = ({route, navigation}) => {
 
         if (!code) {
           controller.CANCEL({
-            serverErrorCode: VCIServerErrorCode.INVALID_REQUEST,
-            serverErrorDescription: 'Authorization server did not return code',
+            issuerErrorCode: VCIServerErrorCode.INVALID_REQUEST,
+            issuerErrorDescription: 'Authorization server did not return code',
           });
 
           navigation.goBack();
@@ -130,8 +130,8 @@ const AuthWebViewScreen: React.FC<any> = ({route, navigation}) => {
         return false;
       } catch (err: any) {
         controller.CANCEL({
-          serverErrorCode: 'redirect_parse_error',
-          serverErrorDescription: err?.message,
+          issuerErrorCode: 'redirect_parse_error',
+          issuerErrorDescription: err?.message,
         });
 
         navigation.goBack();

--- a/screens/Issuers/IssuerScreenController.tsx
+++ b/screens/Issuers/IssuerScreenController.tsx
@@ -95,9 +95,9 @@ export function useIssuerScreenController({route, navigation}) {
       selectIsCredentialOfferViaDeepLink,
     ),
 
-    CANCEL: ({serverErrorCode = '', serverErrorDescription = ''} = {}) =>
+    CANCEL: ({issuerErrorCode = '', issuerErrorDescription = ''} = {}) =>
       service.send(
-        IssuerScreenTabEvents.CANCEL({serverErrorCode, serverErrorDescription}),
+        IssuerScreenTabEvents.CANCEL({issuerErrorCode, issuerErrorDescription}),
       ),
     SELECTED_ISSUER: id =>
       service.send(IssuerScreenTabEvents.SELECTED_ISSUER(id)),

--- a/shared/vciClient/VciClient.ts
+++ b/shared/vciClient/VciClient.ts
@@ -4,16 +4,18 @@ import {
   SelectedCredentialsForVPSharing,
   VerifiableCredential,
 } from '../../machines/VerifiableCredential/VCMetaMachine/vc';
-import {getWalletConfig, jsonLdCanonicalize} from '../openID4VP/OpenID4VPHelper';
+import {
+  getWalletConfig,
+  jsonLdCanonicalize,
+} from '../openID4VP/OpenID4VPHelper';
 
 const emitter = new NativeEventEmitter(NativeModules.InjiVciClient);
 
 export type VciClientErrorResponse = {
   code?: string;
   message?: string;
-  serverErrorCode?: string;
-  serverErrorMessage?: string;
-  sourceErrorCode?: string;
+  issuerErrorCode?: string;
+  issuerErrorMessage?: string;
 };
 class VciClient {
   private static instance: VciClient;
@@ -165,20 +167,19 @@ class VciClient {
         clientId: 'wallet',
         redirectUri: 'io.mosip.residentapp.inji://oauthredirect',
       };
-      const openId4VpWalletConfig = await getWalletConfig()
+      const openId4VpWalletConfig = await getWalletConfig();
       response = await this.InjiVciClient.requestCredentialByOffer(
         credentialOffer,
         JSON.stringify(clientMetadata),
-        openId4VpWalletConfig
+        openId4VpWalletConfig,
       );
     } catch (error) {
       console.error('Error requesting credential by offer:', error);
       const errorResponse: VciClientErrorResponse = {
         code: error?.code ?? 'UNKNOWN_ERROR',
         message: error?.message ?? 'An unknown error occurred',
-        serverErrorCode: error?.userInfo?.serverErrorCode,
-        serverErrorMessage: error?.userInfo?.serverErrorDescription,
-        sourceErrorCode: error?.userInfo?.sourceErrorCode,
+        issuerErrorCode: error?.userInfo?.issuerErrorCode,
+        issuerErrorMessage: error?.userInfo?.issuerErrorDescription,
       };
       throw errorResponse;
     } finally {
@@ -258,21 +259,20 @@ class VciClient {
 
     let response = '';
     try {
-      const openId4VpWalletConfig = await getWalletConfig()
+      const openId4VpWalletConfig = await getWalletConfig();
       response = await this.InjiVciClient.requestCredentialFromTrustedIssuer(
         credentialIssuerUri,
         credentialConfigurationId,
         JSON.stringify(clientMetadata),
-        openId4VpWalletConfig
+        openId4VpWalletConfig,
       );
     } catch (error) {
       console.error('Error requesting credential from trusted issuer:', error);
       const errorResponse: VciClientErrorResponse = {
         code: error?.code ?? 'UNKNOWN_ERROR',
         message: error?.message ?? 'An unknown error occurred',
-        serverErrorCode: error?.userInfo?.serverErrorCode,
-        serverErrorMessage: error?.userInfo?.serverErrorDescription,
-        sourceErrorCode: error?.userInfo?.sourceErrorCode,
+        issuerErrorCode: error?.userInfo?.issuerErrorCode,
+        issuerErrorMessage: error?.userInfo?.issuerErrorDescription,
       };
       throw errorResponse;
     } finally {


### PR DESCRIPTION
Updates the wallet to the renamed `VCIClientException` API from inji-vci-client:

- `serverErrorCode`/`serverErrorDescription` → `issuerErrorCode`/`issuerErrorDescription` in the Android/iOS native bridges, `VciClient.ts`, and the Issuers machine/screens.
- `sourceErrorCode` is removed upstream; the now root-resolving `code` field is used for the `VCI-007`/`VCI-008` checks instead.

Companion to inji-vci-client (Android) and inji-vci-client-ios-swift PR #101.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error UI layout so the message/header is consistently shown before any additional details.
  * Standardized error reporting across credential and authentication flows to surface issuer error code/description/message (including better fallback behavior).
  * Updated Base64 signature encoding to use no-wrap output.

* **Tests**
  * Updated and expanded error-handling tests to match the new issuer error payload fields and mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->