### PR TITLE
fix(iOS): loader stuck on error of wallet binding

### DIFF
--- a/ios/RNOpenID4VPModule.swift
+++ b/ios/RNOpenID4VPModule.swift
@@ -25,7 +25,6 @@ class RNOpenId4VpModule: NSObject, RCTBridgeModule {
           try await self.invokeJsonLdCanonicalize(data)
         }
       )
-      print("Initialized instance :party")
       resolve(true)
     } catch {
       os_log("Error occurred while initialization of OVP instance \(error)")
@@ -48,9 +47,7 @@ class RNOpenId4VpModule: NSObject, RCTBridgeModule {
     }
   }
   
-  private func invokeJsonLdExpand(_ data: [String: Any]) async throws -> [String: Any] {
-    print("data = \(data)")
-    
+  private func invokeJsonLdExpand(_ data: [String: Any]) async throws -> [String: Any] {    
     if let bridge = RCTBridge.current() {
       bridge.eventDispatcher().sendAppEvent(
         withName: "onJsonLdExpand",

--- a/ios/RNVCIClientModule.swift
+++ b/ios/RNVCIClientModule.swift
@@ -508,9 +508,6 @@ class RNVCIClientModule: NSObject, RCTBridgeModule {
   }
   
   private func invokeJsonLdCanonicalize(_ data: String) async throws -> String {
-    
-    print("data = \(data)")
-    
     if let bridge = RCTBridge.current() {
       bridge.eventDispatcher().sendAppEvent(
         withName: "onJsonLdCanonicalize",

--- a/screens/Home/MyVcs/WalletBinding.test.tsx
+++ b/screens/Home/MyVcs/WalletBinding.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import {render} from '@testing-library/react-native';
 import {WalletVerified, WalletBinding} from './WalletBinding';
+import {useOverlayVisibleAfterTimeout} from '../../../shared/hooks/useOverlayVisibleAfterTimeout';
+import {isAndroid} from '../../../shared/constants';
+
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-var-requires */
 
 jest.mock('../../../components/KebabPopUpController', () => ({
   useKebabPopUp: () => ({
@@ -19,6 +23,9 @@ jest.mock('../../../components/KebabPopUpController', () => ({
   }),
 }));
 
+jest.mock('../../../shared/hooks/useOverlayVisibleAfterTimeout');
+jest.mock('../../../shared/constants');
+
 jest.mock('./BindingVcWarningOverlay', () => ({
   BindingVcWarningOverlay: () => 'BindingVcWarningOverlay',
 }));
@@ -34,6 +41,8 @@ jest.mock('../../../components/MessageOverlay', () => ({
   },
 }));
 
+/* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-var-requires */
+
 describe('WalletVerified', () => {
   it('should match snapshot', () => {
     const {toJSON} = render(<WalletVerified />);
@@ -43,11 +52,78 @@ describe('WalletVerified', () => {
 
 describe('WalletBinding', () => {
   const defaultProps = {
-    service: {} as any,
-    vcMetadata: {} as any,
+    service: {} as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    vcMetadata: {} as any, // eslint-disable-line @typescript-eslint/no-explicit-any
   };
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useOverlayVisibleAfterTimeout as jest.Mock).mockImplementation((visible) => visible);
+    (isAndroid as jest.Mock).mockReturnValue(false);
+  });
+
+  describe('useOverlayVisibleAfterTimeout for walletBindingInProgress', () => {
+    it('should call useOverlayVisibleAfterTimeout with walletBindingInProgress state', () => {
+      render(<WalletBinding {...defaultProps} />);
+
+      expect(useOverlayVisibleAfterTimeout).toHaveBeenCalledWith(
+        expect.any(Boolean),
+        expect.any(Number)
+      );
+    });
+
+    it('should pass iOS delay of 200ms when platform is iOS', () => {
+      (isAndroid as jest.Mock).mockReturnValue(false);
+
+      render(<WalletBinding {...defaultProps} />);
+
+      const calls = (useOverlayVisibleAfterTimeout as jest.Mock).mock.calls;
+      expect(calls[0][1]).toBe(200); // First call: walletBindingInProgress
+    });
+
+    it('should pass Android delay of 0ms when platform is Android', () => {
+      (isAndroid as jest.Mock).mockReturnValue(true);
+
+      render(<WalletBinding {...defaultProps} />);
+
+      const calls = (useOverlayVisibleAfterTimeout as jest.Mock).mock.calls;
+      expect(calls[0][1]).toBe(0); // First call: walletBindingInProgress
+    });
+  });
+
+  describe('useOverlayVisibleAfterTimeout for walletBindingError', () => {
+    it('should pass iOS delay of 200ms when platform is iOS for walletBindingError call', () => {
+      (isAndroid as jest.Mock).mockReturnValue(false);
+
+      render(<WalletBinding {...defaultProps} />);
+
+      const calls = (useOverlayVisibleAfterTimeout as jest.Mock).mock.calls;
+      expect(calls.length).toBe(2);
+      expect(calls[1][1]).toBe(200); // Second call: walletBindingError
+    });
+
+    it('should pass Android delay of 0ms when platform is Android for walletBindingError call', () => {
+      (isAndroid as jest.Mock).mockReturnValue(true);
+
+      render(<WalletBinding {...defaultProps} />);
+
+      const calls = (useOverlayVisibleAfterTimeout as jest.Mock).mock.calls;
+      expect(calls.length).toBe(2);
+      expect(calls[1][1]).toBe(0); // Second call: walletBindingError
+    });
+
+    it('should pass false for walletBindingError when error is empty', () => {
+      render(<WalletBinding {...defaultProps} />);
+
+      const calls = (useOverlayVisibleAfterTimeout as jest.Mock).mock.calls;
+      // Second call is for walletBindingError - should have false (no error)
+      expect(calls[1][0]).toBe(false);
+    });
+  });
+
   it('should match snapshot', () => {
+    (useOverlayVisibleAfterTimeout as jest.Mock).mockImplementation((visible) => visible);
+
     const {toJSON} = render(<WalletBinding {...defaultProps} />);
     expect(toJSON()).toMatchSnapshot();
   });

--- a/screens/Home/MyVcs/WalletBinding.tsx
+++ b/screens/Home/MyVcs/WalletBinding.tsx
@@ -10,8 +10,8 @@ import {ActorRefFrom} from 'xstate';
 import {VCMetadata} from '../../../shared/VCMetadata';
 import {TelemetryConstants} from '../../../shared/telemetry/TelemetryConstants';
 import {VCItemMachine} from '../../../machines/VerifiableCredential/VCItemMachine/VCItemMachine';
-import {useOverlayVisibleAfterTimeout} from "../../../shared/hooks/useOverlayVisibleAfterTimeout";
-import {isAndroid} from "../../../shared/constants";
+import {useOverlayVisibleAfterTimeout} from '../../../shared/hooks/useOverlayVisibleAfterTimeout';
+import {isAndroid} from '../../../shared/constants';
 
 export const WalletVerified: React.FC = () => {
   return (
@@ -28,8 +28,14 @@ export const WalletBinding: React.FC<WalletBindingProps> = props => {
   const controller = useKebabPopUp(props);
   const {t} = useTranslation('WalletBinding');
   const delay = isAndroid() ? 0 : 200;
-  const walletBindingInProgress = useOverlayVisibleAfterTimeout(controller.walletBindingInProgress, delay);
-  const isWalletBindingError = useOverlayVisibleAfterTimeout(!!controller.walletBindingError, delay);
+  const isWalletBindingInProgress = useOverlayVisibleAfterTimeout(
+    controller.walletBindingInProgress,
+    delay,
+  );
+  const isWalletBindingError = useOverlayVisibleAfterTimeout(
+    !!controller.walletBindingError,
+    delay,
+  );
 
   return (
     <>
@@ -53,7 +59,7 @@ export const WalletBinding: React.FC<WalletBindingProps> = props => {
         />
       )}
 
-       <MessageOverlay
+      <MessageOverlay
         key="walletBindingError"
         testID="walletBindingError"
         isVisible={isWalletBindingError}
@@ -62,8 +68,8 @@ export const WalletBinding: React.FC<WalletBindingProps> = props => {
         onButtonPress={controller.CANCEL}
       />
       <MessageOverlay
-        key={"walletBindingProgress"}
-        isVisible={walletBindingInProgress}
+        key={'walletBindingProgress'}
+        isVisible={isWalletBindingInProgress}
         title={t('inProgress')}
         progress
       />

--- a/screens/Home/MyVcs/WalletBinding.tsx
+++ b/screens/Home/MyVcs/WalletBinding.tsx
@@ -10,6 +10,8 @@ import {ActorRefFrom} from 'xstate';
 import {VCMetadata} from '../../../shared/VCMetadata';
 import {TelemetryConstants} from '../../../shared/telemetry/TelemetryConstants';
 import {VCItemMachine} from '../../../machines/VerifiableCredential/VCItemMachine/VCItemMachine';
+import {useOverlayVisibleAfterTimeout} from "../../../shared/hooks/useOverlayVisibleAfterTimeout";
+import {isAndroid} from "../../../shared/constants";
 
 export const WalletVerified: React.FC = () => {
   return (
@@ -25,6 +27,10 @@ export const WalletVerified: React.FC = () => {
 export const WalletBinding: React.FC<WalletBindingProps> = props => {
   const controller = useKebabPopUp(props);
   const {t} = useTranslation('WalletBinding');
+  const delay = isAndroid() ? 0 : 200;
+  const walletBindingInProgress = useOverlayVisibleAfterTimeout(controller.walletBindingInProgress, delay);
+  const isWalletBindingError = useOverlayVisibleAfterTimeout(!!controller.walletBindingError, delay);
+
   return (
     <>
       <BindingVcWarningOverlay
@@ -47,14 +53,17 @@ export const WalletBinding: React.FC<WalletBindingProps> = props => {
         />
       )}
 
-      <MessageOverlay
+       <MessageOverlay
+        key="walletBindingError"
         testID="walletBindingError"
-        isVisible={controller.isWalletBindingError}
+        isVisible={isWalletBindingError}
         title={controller.walletBindingError}
+        onBackdropPress={controller.CANCEL}
         onButtonPress={controller.CANCEL}
       />
       <MessageOverlay
-        isVisible={controller.walletBindingInProgress}
+        key={"walletBindingProgress"}
+        isVisible={walletBindingInProgress}
         title={t('inProgress')}
         progress
       />

--- a/shared/hooks/useOverlayVisibleAfterTimeout.test.ts
+++ b/shared/hooks/useOverlayVisibleAfterTimeout.test.ts
@@ -1,14 +1,23 @@
 describe('useOverlayVisibleAfterTimeout', () => {
   let mockSetVisible: jest.Mock;
-  let effectCallback: Function;
+  let effectCallback: any;
+  let cleanupCallback: any;
   let timeoutRef: {current: ReturnType<typeof setTimeout> | null};
+  let mockClearTimeout: jest.SpyInstance;
+  let mockSetTimeout: jest.SpyInstance;
+  let useOverlayVisibleAfterTimeout: any;
 
   beforeEach(() => {
     jest.useFakeTimers();
     jest.resetModules();
     mockSetVisible = jest.fn();
-    effectCallback = null as any;
+    effectCallback = null;
+    cleanupCallback = null;
     timeoutRef = {current: null};
+
+    // Spy on clearTimeout and setTimeout to track calls
+    mockClearTimeout = jest.spyOn(global, 'clearTimeout');
+    mockSetTimeout = jest.spyOn(global, 'setTimeout');
 
     jest.spyOn(require('react'), 'useState').mockImplementation((init: any) => {
       return [init, mockSetVisible];
@@ -16,9 +25,13 @@ describe('useOverlayVisibleAfterTimeout', () => {
     jest.spyOn(require('react'), 'useRef').mockReturnValue(timeoutRef);
     jest
       .spyOn(require('react'), 'useEffect')
-      .mockImplementation((cb: Function) => {
-        effectCallback = cb;
+      .mockImplementation((cb: any) => {
+        effectCallback = () => {
+          cleanupCallback = cb();
+        };
       });
+
+    useOverlayVisibleAfterTimeout = require('./useOverlayVisibleAfterTimeout').useOverlayVisibleAfterTimeout;
   });
 
   afterEach(() => {
@@ -27,24 +40,15 @@ describe('useOverlayVisibleAfterTimeout', () => {
   });
 
   it('should export useOverlayVisibleAfterTimeout', () => {
-    const {
-      useOverlayVisibleAfterTimeout,
-    } = require('./useOverlayVisibleAfterTimeout');
     expect(typeof useOverlayVisibleAfterTimeout).toBe('function');
   });
 
   it('should return false by default', () => {
-    const {
-      useOverlayVisibleAfterTimeout,
-    } = require('./useOverlayVisibleAfterTimeout');
     const result = useOverlayVisibleAfterTimeout();
     expect(result).toBe(false);
   });
 
   it('should set timeout when visibleStart is true', () => {
-    const {
-      useOverlayVisibleAfterTimeout,
-    } = require('./useOverlayVisibleAfterTimeout');
     useOverlayVisibleAfterTimeout(true, 500);
     effectCallback();
     expect(timeoutRef.current).not.toBeNull();
@@ -53,11 +57,162 @@ describe('useOverlayVisibleAfterTimeout', () => {
   });
 
   it('should clear timeout and set visible false when visibleStart is false', () => {
-    const {
-      useOverlayVisibleAfterTimeout,
-    } = require('./useOverlayVisibleAfterTimeout');
     useOverlayVisibleAfterTimeout(false, 500);
     effectCallback();
     expect(mockSetVisible).toHaveBeenCalledWith(false);
+  });
+
+  it('should clear existing timeout when timeoutRef.current is already set', () => {
+
+    // Simulate a timeout already being set
+    const existingTimeoutId = 12345 as any;
+    timeoutRef.current = existingTimeoutId;
+
+    // Call effect with visibleStart true
+    useOverlayVisibleAfterTimeout(true, 500);
+    effectCallback();
+
+    // Verify clearTimeout was called for the existing timeout
+    expect(mockClearTimeout).toHaveBeenCalledWith(existingTimeoutId);
+    // Verify a new timeout was set
+    expect(mockSetTimeout).toHaveBeenCalled();
+  });
+
+  it('should clear timeout and set timeoutRef.current to null when visibleStart is false', () => {
+
+    // Simulate a timeout already being set
+    const existingTimeoutId = 12345 as any;
+    timeoutRef.current = existingTimeoutId;
+
+    // Call effect with visibleStart false
+    useOverlayVisibleAfterTimeout(false, 500);
+    effectCallback();
+
+    // Verify clearTimeout was called
+    expect(mockClearTimeout).toHaveBeenCalledWith(existingTimeoutId);
+    // Verify setVisible(false) was called
+    expect(mockSetVisible).toHaveBeenCalledWith(false);
+    // Verify timeoutRef.current is set to null
+    expect(timeoutRef.current).toBeNull();
+  });
+
+  it('should execute cleanup function and clear timeout on unmount', () => {
+
+    // Setup: Create active timeout
+    const activeTimeoutId = 67890 as any;
+    timeoutRef.current = activeTimeoutId;
+
+    useOverlayVisibleAfterTimeout(true, 500);
+    effectCallback();
+
+    // Execute cleanup function (simulating unmount)
+    if (cleanupCallback) {
+      cleanupCallback();
+    }
+
+    // Verify clearTimeout was called in cleanup
+    expect(mockClearTimeout).toHaveBeenCalledWith(activeTimeoutId);
+    // Verify timeoutRef.current is null after cleanup
+    expect(timeoutRef.current).toBeNull();
+  });
+
+  it('should use default parameters when not provided', () => {
+
+    // Call without parameters (should use defaults: visibleStart = false, ms = 1000)
+    useOverlayVisibleAfterTimeout();
+    effectCallback();
+
+    // Should set visible to false (default visibleStart is false)
+    expect(mockSetVisible).toHaveBeenCalledWith(false);
+    // Timeout should not be set since visibleStart is false
+    expect(mockSetTimeout).not.toHaveBeenCalled();
+  });
+
+  it('should handle multiple dependency changes while timeout is pending', () => {
+
+    // First call: start timeout
+    const firstTimeoutId = 11111 as any;
+    timeoutRef.current = firstTimeoutId;
+    mockSetTimeout.mockReturnValueOnce(firstTimeoutId);
+
+    useOverlayVisibleAfterTimeout(true, 500);
+    effectCallback();
+
+    mockSetTimeout.mockClear();
+    mockClearTimeout.mockClear();
+
+    // Second call: change ms parameter (should clear first timeout)
+    const secondTimeoutId = 22222 as any;
+    timeoutRef.current = firstTimeoutId; // Simulate active timeout
+    mockSetTimeout.mockReturnValueOnce(secondTimeoutId);
+
+    useOverlayVisibleAfterTimeout(true, 1000);
+    effectCallback();
+
+    // Verify first timeout was cleared
+    expect(mockClearTimeout).toHaveBeenCalledWith(firstTimeoutId);
+    // Verify new timeout was set with new duration
+    expect(mockSetTimeout).toHaveBeenCalledWith(expect.any(Function), 1000);
+  });
+
+  it('should transition from visibleStart true to false during active timeout', () => {
+
+    // First: Start with timeout
+    const firstTimeoutId = 55555 as any;
+    timeoutRef.current = firstTimeoutId;
+    mockSetTimeout.mockReturnValueOnce(firstTimeoutId);
+
+    useOverlayVisibleAfterTimeout(true, 500);
+    effectCallback();
+
+    expect(mockSetTimeout).toHaveBeenCalled();
+
+    mockSetTimeout.mockClear();
+    mockClearTimeout.mockClear();
+    mockSetVisible.mockClear();
+
+    // Second: Change to visibleStart false
+    timeoutRef.current = firstTimeoutId;
+    useOverlayVisibleAfterTimeout(false, 500);
+    effectCallback();
+
+    // Verify timeout was cleared
+    expect(mockClearTimeout).toHaveBeenCalledWith(firstTimeoutId);
+    // Verify visible was set to false
+    expect(mockSetVisible).toHaveBeenCalledWith(false);
+    // Verify no new timeout was created
+    expect(mockSetTimeout).not.toHaveBeenCalled();
+  });
+
+  it('should not set timeout when visibleStart is false even after cleanup', () => {
+
+    useOverlayVisibleAfterTimeout(false, 500);
+    effectCallback();
+
+    // Execute cleanup
+    if (cleanupCallback) {
+      cleanupCallback();
+    }
+
+    // Verify timeout was never created
+    expect(mockSetTimeout).not.toHaveBeenCalled();
+    // Verify setVisible(false) was called at least once
+    expect(mockSetVisible).toHaveBeenCalledWith(false);
+  });
+
+  it('should advance time and fire timeout callback with jest.advanceTimersByTime', () => {
+
+    useOverlayVisibleAfterTimeout(true, 1500);
+    effectCallback();
+
+    mockSetVisible.mockClear();
+
+    // Advance partway through timeout
+    jest.advanceTimersByTime(1000);
+    expect(mockSetVisible).not.toHaveBeenCalledWith(true);
+
+    // Advance to complete timeout
+    jest.advanceTimersByTime(500);
+    expect(mockSetVisible).toHaveBeenCalledWith(true);
   });
 });

--- a/shared/hooks/useOverlayVisibleAfterTimeout.test.ts
+++ b/shared/hooks/useOverlayVisibleAfterTimeout.test.ts
@@ -1,21 +1,19 @@
 describe('useOverlayVisibleAfterTimeout', () => {
   let mockSetVisible: jest.Mock;
-  let mockSetSavingTimeout: jest.Mock;
   let effectCallback: Function;
+  let timeoutRef: {current: ReturnType<typeof setTimeout> | null};
 
   beforeEach(() => {
     jest.useFakeTimers();
     jest.resetModules();
     mockSetVisible = jest.fn();
-    mockSetSavingTimeout = jest.fn();
     effectCallback = null as any;
+    timeoutRef = {current: null};
 
-    let callCount = 0;
     jest.spyOn(require('react'), 'useState').mockImplementation((init: any) => {
-      callCount++;
-      if (callCount % 2 === 1) return [init, mockSetVisible];
-      return [init, mockSetSavingTimeout];
+      return [init, mockSetVisible];
     });
+    jest.spyOn(require('react'), 'useRef').mockReturnValue(timeoutRef);
     jest
       .spyOn(require('react'), 'useEffect')
       .mockImplementation((cb: Function) => {
@@ -49,7 +47,7 @@ describe('useOverlayVisibleAfterTimeout', () => {
     } = require('./useOverlayVisibleAfterTimeout');
     useOverlayVisibleAfterTimeout(true, 500);
     effectCallback();
-    expect(mockSetSavingTimeout).toHaveBeenCalled();
+    expect(timeoutRef.current).not.toBeNull();
     jest.advanceTimersByTime(500);
     expect(mockSetVisible).toHaveBeenCalledWith(true);
   });

--- a/shared/hooks/useOverlayVisibleAfterTimeout.ts
+++ b/shared/hooks/useOverlayVisibleAfterTimeout.ts
@@ -1,23 +1,33 @@
-import { useEffect, useState } from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 export const useOverlayVisibleAfterTimeout = (
   visibleStart = false,
   ms = 1000
 ) => {
   const [visible, setVisible] = useState(false);
-  const [savingTimeout, setSavingTimeout] = useState(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+
     if (visibleStart) {
-      const timeoutID = setTimeout(() => {
+      timeoutRef.current = setTimeout(() => {
         setVisible(true);
       }, ms);
-      setSavingTimeout(timeoutID);
     } else {
-      clearTimeout(savingTimeout);
       setVisible(false);
     }
-  }, [visibleStart]);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, [visibleStart, ms]);
 
   return visible;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet binding overlays by delaying visibility on non-Android devices (0ms on Android) based on binding progress and error state.

* **New Features**
  * Enhanced overlay timing behavior through a more reliable “show after timeout” hook lifecycle.

* **Tests**
  * Expanded wallet binding test coverage for platform-specific timing and error edge cases.
  * Updated `useOverlayVisibleAfterTimeout` tests to match the revised timeout behavior.

* **Chores**
  * Removed native debug logging to reduce unnecessary stdout output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Relates: https://github.com/inji/inji-wallet/issues/2488