### PR TITLE
Sync Improve WalletConfig and VPTokenSigningResult / UnsignedVPToken changes in library

### DIFF
--- a/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
+++ b/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
@@ -1,5 +1,6 @@
 package io.mosip.residentapp;
 
+import static io.mosip.residentapp.utils.OpenId4VPUtils.parseUnsignedVPTokens;
 import static io.mosip.residentapp.utils.OpenId4VPUtils.parseVPTokenSigningResults;
 import static io.mosip.residentapp.utils.OpenId4VPUtils.parseWalletConfig;
 
@@ -23,6 +24,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.List;
@@ -97,26 +99,17 @@ public class InjiOpenID4VPModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void constructUnsignedVPToken(ReadableMap selectedVCs, Promise promise) {
-        try {
-            Map<String, List<Credential>> selectedCredentials = OpenId4VPUtils.parseSelectedVCs(selectedVCs);
-            List<UnsignedVPToken> vpTokens = openID4VP.constructUnsignedVPToken(selectedCredentials);
+      try {
+        Map<String, List<Credential>> selectedCredentials = OpenId4VPUtils.parseSelectedVCs(selectedVCs);
+        List<UnsignedVPToken> vpTokens = openID4VP.constructUnsignedVPToken(selectedCredentials);
 
-            JSONArray jsonArray = new JSONArray();
-            for (UnsignedVPToken token : vpTokens) {
-                JSONObject obj = new JSONObject();
-                obj.put("format", token.getFormat().getValue());
-                obj.put("holderKeyReference", token.getHolderKeyReference());
-                obj.put("signatureAlgorithm", token.getSignatureAlgorithm());
-                obj.put("dataToSign", Base64.encodeToString(token.getDataToSign(), Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING));
-                jsonArray.put(obj);
-            }
-            promise.resolve(jsonArray.toString());
-        } catch (Exception e) {
-            rejectWithOpenID4VPExceptions(e, promise);
-        }
+        promise.resolve(parseUnsignedVPTokens(vpTokens));
+      } catch (Exception e) {
+        rejectWithOpenID4VPExceptions(e, promise);
+      }
     }
 
-    @ReactMethod
+  @ReactMethod
     public void getMatchingCredentials(ReadableMap vpRequest, ReadableArray availableWalletCredentials,
                                        Promise promise) {
       try {

--- a/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
+++ b/android/app/src/main/java/io/mosip/residentapp/InjiOpenID4VPModule.java
@@ -150,12 +150,14 @@ public class InjiOpenID4VPModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     private void rejectWithOpenID4VPExceptions(Exception e, Promise promise) {
+        Log.e("OpenID4VPBridge", "Exception occurred. Details: "+ e.getMessage() +" | Cause: "+e.getCause());
+
         if (e instanceof OpenID4VPExceptions exception) {
             WritableMap errorMap = Arguments.createMap();
             errorMap.putString("errorCode", exception.getErrorCode());
             errorMap.putString("message", exception.getMessage());
             errorMap.putString("verifierResponse", gson.toJson(exception.getVerifierResponse()));
-            errorMap.putString("cause", gson.toJson(exception.getCause()));
+            errorMap.putString("cause", exception.getCause() != null ? exception.getCause().getMessage() : "Source is the cause");
 
             promise.reject(exception.getErrorCode(), exception.getMessage(), exception, errorMap);
         } else {

--- a/android/app/src/main/java/io/mosip/residentapp/InjiVCIClientCallback.kt
+++ b/android/app/src/main/java/io/mosip/residentapp/InjiVCIClientCallback.kt
@@ -78,6 +78,7 @@ object VCIClientCallbackBridge {
         payload.forEach { v ->
           pushMap(
             Arguments.createMap().apply {
+              putString("id", v.id)
               putString("dataToSign",
                 Base64.encodeToString(
                   v.dataToSign,

--- a/android/app/src/main/java/io/mosip/residentapp/utils/OpenId4VPUtils.java
+++ b/android/app/src/main/java/io/mosip/residentapp/utils/OpenId4VPUtils.java
@@ -28,13 +28,13 @@ import io.mosip.openID4VP.authorizationRequest.VPFormatSupported;
 import io.mosip.openID4VP.authorizationRequest.Verifier;
 import io.mosip.openID4VP.authorizationRequest.WalletConfig;
 import io.mosip.openID4VP.authorizationRequest.WalletConfigDefaultsKt;
+import io.mosip.openID4VP.authorizationResponse.unsignedVPToken.UnsignedVPToken;
 import io.mosip.openID4VP.authorizationResponse.vpTokenSigningResult.VPTokenSigningResult;
 import io.mosip.openID4VP.common.OpenID4VPErrorCodes;
 import io.mosip.openID4VP.constants.ClientIdPrefix;
 import io.mosip.openID4VP.constants.EncryptionAlgorithm;
 import io.mosip.openID4VP.constants.EncryptionMethod;
 import io.mosip.openID4VP.constants.ProofType;
-import io.mosip.openID4VP.constants.RequestUriMethod;
 import io.mosip.openID4VP.constants.ResponseType;
 import io.mosip.openID4VP.constants.SignatureAlgorithm;
 import io.mosip.openID4VP.constants.SpecVersion;
@@ -49,6 +49,12 @@ import kotlinx.serialization.json.Json;
 
 import static io.mosip.openID4VP.common.OpenID4VPErrorCodes.ACCESS_DENIED;
 import static io.mosip.openID4VP.common.OpenID4VPErrorCodes.INVALID_TRANSACTION_DATA;
+
+import androidx.annotation.NonNull;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 public class OpenId4VPUtils {
   public static WalletConfig parseWalletConfig(ReadableMap walletConfigMap) {
@@ -72,13 +78,11 @@ public class OpenId4VPUtils {
     List<ResponseType> responseTypes = convertReadableArrayToEnumList(
       walletConfigMap, "response_types_supported", ResponseType.Companion::fromValue);
 
-    Boolean presentationDefinitionUriSupported = walletConfigMap.hasKey("presentation_definition_uri_supported")
-      ? walletConfigMap.getBoolean("presentation_definition_uri_supported")
-      : true;
+    boolean presentationDefinitionUriSupported = !walletConfigMap.hasKey("presentation_definition_uri_supported")
+      || walletConfigMap.getBoolean("presentation_definition_uri_supported");
 
-    boolean validatePreRegiseredVerifier = walletConfigMap.hasKey("validate_pre_registered_verifier") ? walletConfigMap.getBoolean("validate_pre_registered_verifier") : true;
+    boolean validateTrustedVerifier = !walletConfigMap.hasKey("validate_trusted_verifier") || walletConfigMap.getBoolean("validate_trusted_verifier");
 
-    List<RequestUriMethod> supportedRequestUriMethods = parseSupportedRequestUriMethods(walletConfigMap);
 
     List<Verifier> trustedVerifiers = parseTrustedVerifiers(walletConfigMap);
 
@@ -90,26 +94,9 @@ public class OpenId4VPUtils {
       encryptionEnc,
       responseTypes != null ? responseTypes : WalletConfigDefaultsKt.getDefaultResponseTypeSupported(),
       presentationDefinitionUriSupported,
-      supportedRequestUriMethods,
       trustedVerifiers,
-      validatePreRegiseredVerifier
+      validateTrustedVerifier
     );
-  }
-
-
-  private static List<RequestUriMethod> parseSupportedRequestUriMethods(ReadableMap walletConfigMap) {
-    if (!walletConfigMap.hasKey("request_uri_methods_supported")) {
-      return List.of(RequestUriMethod.GET, RequestUriMethod.POST);
-    }
-    ReadableArray methodsArray = walletConfigMap.getArray("request_uri_methods_supported");
-    List<RequestUriMethod> methods = new ArrayList<>();
-    for (int i = 0; i < Objects.requireNonNull(methodsArray).size(); i++) {
-      RequestUriMethod method = RequestUriMethod.Companion.fromValue(methodsArray.getString(i));
-      if (method != null) {
-        methods.add(method);
-      }
-    }
-    return methods;
   }
 
   private static List<Verifier> parseTrustedVerifiers(ReadableMap walletConfigMap) {
@@ -262,10 +249,12 @@ public class OpenId4VPUtils {
       }
 
       String signedData = vpTokenSigningResultMap.getString("signedData");
+      String id = vpTokenSigningResultMap.getString("id");
       byte[] signedDataBytes = Base64.decode(signedData, Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
 
+      assert id != null;
       formattedVpTokenSigningResults.add(
-        new VPTokenSigningResult(signedDataBytes));
+        new VPTokenSigningResult(id,signedDataBytes));
     }
 
     return formattedVpTokenSigningResults;
@@ -358,6 +347,21 @@ public class OpenId4VPUtils {
       default:
         return null;
     }
+  }
+
+  @NonNull
+  public static String parseUnsignedVPTokens(List<UnsignedVPToken> vpTokens) throws JSONException {
+    JSONArray jsonArray = new JSONArray();
+    for (UnsignedVPToken token : vpTokens) {
+      JSONObject obj = new JSONObject();
+      obj.put("id", token.getId());
+      obj.put("format", token.getFormat().getValue());
+      obj.put("holderKeyReference", token.getHolderKeyReference());
+      obj.put("signatureAlgorithm", token.getSignatureAlgorithm());
+      obj.put("dataToSign", Base64.encodeToString(token.getDataToSign(), Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING));
+      jsonArray.put(obj);
+    }
+    return jsonArray.toString();
   }
 
   public static OpenID4VPExceptions convertToOpenID4VPException(

--- a/android/app/src/main/java/io/mosip/residentapp/utils/OpenId4VPUtils.java
+++ b/android/app/src/main/java/io/mosip/residentapp/utils/OpenId4VPUtils.java
@@ -78,10 +78,11 @@ public class OpenId4VPUtils {
     List<ResponseType> responseTypes = convertReadableArrayToEnumList(
       walletConfigMap, "response_types_supported", ResponseType.Companion::fromValue);
 
-    boolean presentationDefinitionUriSupported = !walletConfigMap.hasKey("presentation_definition_uri_supported")
-      || walletConfigMap.getBoolean("presentation_definition_uri_supported");
+    boolean presentationDefinitionUriSupported =
+      getBooleanOrDefault(walletConfigMap, "presentation_definition_uri_supported", true);
 
-    boolean validateTrustedVerifier = !walletConfigMap.hasKey("validate_trusted_verifier") || walletConfigMap.getBoolean("validate_trusted_verifier");
+    boolean validateTrustedVerifier =
+      getBooleanOrDefault(walletConfigMap, "validate_trusted_verifier", true);
 
 
     List<Verifier> trustedVerifiers = parseTrustedVerifiers(walletConfigMap);
@@ -244,7 +245,10 @@ public class OpenId4VPUtils {
 
       if (vpTokenSigningResultMap == null
         || !vpTokenSigningResultMap.hasKey("signedData")
-        || vpTokenSigningResultMap.isNull("signedData")) {
+        || vpTokenSigningResultMap.isNull("signedData")
+        || !vpTokenSigningResultMap.hasKey("id")
+        || vpTokenSigningResultMap.isNull("id")
+      ) {
         continue;
       }
 
@@ -252,7 +256,6 @@ public class OpenId4VPUtils {
       String id = vpTokenSigningResultMap.getString("id");
       byte[] signedDataBytes = Base64.decode(signedData, Base64.URL_SAFE | Base64.NO_WRAP | Base64.NO_PADDING);
 
-      assert id != null;
       formattedVpTokenSigningResults.add(
         new VPTokenSigningResult(id,signedDataBytes));
     }

--- a/components/VC/Views/VCCardViewContent.tsx
+++ b/components/VC/Views/VCCardViewContent.tsx
@@ -145,7 +145,7 @@ export const VCCardViewContent: React.FC<VCItemContentProps> = ({
               />
             )}
             <Text weight="semibold"
-                  color={wellknownDisplayProperty.getTextColor(Theme.Colors.plainText)}
+                  color={wellknownDisplayProperty.getTextColor(Theme.Colors.Details)}
                   style={{marginLeft: 8}}>
               {formatKeyLabel(name)}
             </Text>

--- a/ios/Inji.xcodeproj/project.pbxproj
+++ b/ios/Inji.xcodeproj/project.pbxproj
@@ -51,11 +51,10 @@
 		B18059E884C0ABDD17F3DC3D /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC715A2D49A985799AEE119 /* ExpoModulesProvider.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
 		C339223B2E79A536004A01EC /* InjiVcRenderer in Frameworks */ = {isa = PBXBuildFile; productRef = C339223A2E79A536004A01EC /* InjiVcRenderer */; };
-		C3F18B1A2E320C85007DBE73 /* OpenID4VP in Frameworks */ = {isa = PBXBuildFile; productRef = C3F18B192E320C85007DBE73 /* OpenID4VP */; };
 		C3F6A9DD2E661896006C9904 /* RNInjiVcRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F6A9DC2E66188D006C9904 /* RNInjiVcRenderer.swift */; };
 		C3F6A9DF2E661903006C9904 /* RNInjiVcRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = C3F6A9DE2E6618F6006C9904 /* RNInjiVcRenderer.m */; };
-		E6AE1F022FDC2946001AE284 /* VCIClient in Frameworks */ = {isa = PBXBuildFile; productRef = E6AE1F012FDC2946001AE284 /* VCIClient */; };
-		E6BCD5CF2FDA9BED00C51482 /* VCIClient in Frameworks */ = {isa = PBXBuildFile; productRef = E6BCD5CE2FDA9BED00C51482 /* VCIClient */; };
+		E641C9E62FEAE9C9002D18A7 /* VCIClient in Frameworks */ = {isa = PBXBuildFile; productRef = E641C9E52FEAE9C9002D18A7 /* VCIClient */; };
+		E660F6FB2FF23611007D2934 /* OpenID4VP in Frameworks */ = {isa = PBXBuildFile; productRef = E660F6FA2FF23611007D2934 /* OpenID4VP */; };
 		E6D946DA2EFAA2FE004DA688 /* CredentialsVerifierConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D946C62EFAA2FE004DA688 /* CredentialsVerifierConstant.swift */; };
 		E6D946DB2EFAA2FE004DA688 /* NetworkManagerClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D946D42EFAA2FE004DA688 /* NetworkManagerClient.swift */; };
 		E6D946DC2EFAA2FE004DA688 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D946CF2EFAA2FE004DA688 /* Data.swift */; };
@@ -186,13 +185,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E641C9E62FEAE9C9002D18A7 /* VCIClient in Frameworks */,
 				9CCC57772E9D7C7000669DB7 /* ios-tuvali-library in Frameworks */,
-				E6BCD5CF2FDA9BED00C51482 /* VCIClient in Frameworks */,
-				E6AE1F022FDC2946001AE284 /* VCIClient in Frameworks */,
 				C339223B2E79A536004A01EC /* InjiVcRenderer in Frameworks */,
 				9CAE74EE2E2E38F800C2532C /* pixelpass in Frameworks */,
 				9CCCA19E2CF87A8400D5A461 /* securekeystore in Frameworks */,
-				C3F18B1A2E320C85007DBE73 /* OpenID4VP in Frameworks */,
+				E660F6FB2FF23611007D2934 /* OpenID4VP in Frameworks */,
 				61450CD968A57153077CB5A9 /* libPods-Inji.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -602,11 +600,10 @@
 			packageProductDependencies = (
 				9CCCA19D2CF87A8400D5A461 /* securekeystore */,
 				9CAE74ED2E2E38F800C2532C /* pixelpass */,
-				C3F18B192E320C85007DBE73 /* OpenID4VP */,
 				C339223A2E79A536004A01EC /* InjiVcRenderer */,
 				9CCC57762E9D7C7000669DB7 /* ios-tuvali-library */,
-				E6BCD5CE2FDA9BED00C51482 /* VCIClient */,
-				E6AE1F012FDC2946001AE284 /* VCIClient */,
+				E641C9E52FEAE9C9002D18A7 /* VCIClient */,
+				E660F6FA2FF23611007D2934 /* OpenID4VP */,
 			);
 			productName = Inji;
 			productReference = 13B07F961A680F5B00A75B9A /* Inji.app */;
@@ -638,10 +635,10 @@
 			packageReferences = (
 				9CCCA19C2CF87A8400D5A461 /* XCRemoteSwiftPackageReference "secure-keystore-ios-swift" */,
 				9CAE74EC2E2E38F800C2532C /* XCRemoteSwiftPackageReference "pixelpass-ios-swift" */,
-				C3F18B182E320C85007DBE73 /* XCRemoteSwiftPackageReference "inji-openid4vp-ios-swift" */,
 				C33922392E79A536004A01EC /* XCRemoteSwiftPackageReference "inji-vc-renderer-ios-swift" */,
 				9CCC57752E9D7C7000669DB7 /* XCRemoteSwiftPackageReference "tuvali-ios-swift" */,
-				E6AE1F002FDC2946001AE284 /* XCRemoteSwiftPackageReference "inji-vci-client-ios-swift" */,
+				E641C9E42FEAE9C9002D18A7 /* XCRemoteSwiftPackageReference "inji-vci-client-ios-swift" */,
+				E660F6F92FF23611007D2934 /* XCRemoteSwiftPackageReference "inji-openid4vp-ios-swift" */,
 			);
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
 			projectDirPath = "";
@@ -1059,7 +1056,10 @@
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1123,7 +1123,10 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "$(inherited)  ";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					" ",
+				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -1189,17 +1192,17 @@
 				version = 0.1.0;
 			};
 		};
-		C3F18B182E320C85007DBE73 /* XCRemoteSwiftPackageReference "inji-openid4vp-ios-swift" */ = {
+		E641C9E42FEAE9C9002D18A7 /* XCRemoteSwiftPackageReference "inji-vci-client-ios-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/inji/inji-openid4vp-ios-swift.git";
+			repositoryURL = "https://github.com/inji/inji-vci-client-ios-swift";
 			requirement = {
 				branch = develop;
 				kind = branch;
 			};
 		};
-		E6AE1F002FDC2946001AE284 /* XCRemoteSwiftPackageReference "inji-vci-client-ios-swift" */ = {
+		E660F6F92FF23611007D2934 /* XCRemoteSwiftPackageReference "inji-openid4vp-ios-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/inji/inji-vci-client-ios-swift";
+			repositoryURL = "https://github.com/inji/inji-openid4vp-ios-swift";
 			requirement = {
 				branch = develop;
 				kind = branch;
@@ -1228,19 +1231,15 @@
 			package = C33922392E79A536004A01EC /* XCRemoteSwiftPackageReference "inji-vc-renderer-ios-swift" */;
 			productName = InjiVcRenderer;
 		};
-		C3F18B192E320C85007DBE73 /* OpenID4VP */ = {
+		E641C9E52FEAE9C9002D18A7 /* VCIClient */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C3F18B182E320C85007DBE73 /* XCRemoteSwiftPackageReference "inji-openid4vp-ios-swift" */;
+			package = E641C9E42FEAE9C9002D18A7 /* XCRemoteSwiftPackageReference "inji-vci-client-ios-swift" */;
+			productName = VCIClient;
+		};
+		E660F6FA2FF23611007D2934 /* OpenID4VP */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E660F6F92FF23611007D2934 /* XCRemoteSwiftPackageReference "inji-openid4vp-ios-swift" */;
 			productName = OpenID4VP;
-		};
-		E6AE1F012FDC2946001AE284 /* VCIClient */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E6AE1F002FDC2946001AE284 /* XCRemoteSwiftPackageReference "inji-vci-client-ios-swift" */;
-			productName = VCIClient;
-		};
-		E6BCD5CE2FDA9BED00C51482 /* VCIClient */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = VCIClient;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Inji.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9a6d644e84bc97a0d6467ec99ae0e07a7805e6cafdba8c4767c20d63e6aaa6a1",
+  "originHash" : "e1f2d509954e8ca6c7f187d3fb6cb3d3d011988b00306f7948dcc9ebf4826839",
   "pins" : [
     {
       "identity" : "aexml",
@@ -76,10 +76,10 @@
     {
       "identity" : "inji-openid4vp-ios-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/inji/inji-openid4vp-ios-swift.git",
+      "location" : "https://github.com/inji/inji-openid4vp-ios-swift",
       "state" : {
         "branch" : "develop",
-        "revision" : "435a5c49cf05fc2a3a6f02b498fe93e25a3ae76a"
+        "revision" : "aa5cdc49c1787be5772e2740796c89451cfef048"
       }
     },
     {
@@ -97,7 +97,7 @@
       "location" : "https://github.com/inji/inji-vci-client-ios-swift",
       "state" : {
         "branch" : "develop",
-        "revision" : "1c3c610ad725397aaccb6bbf0cf71a719b61a71c"
+        "revision" : "7a195c777b8a75e69289f20258de60d28469fce9"
       }
     },
     {

--- a/ios/Utils/OpenId4VPUtils.swift
+++ b/ios/Utils/OpenId4VPUtils.swift
@@ -23,6 +23,7 @@ class OpenId4VPUtils: NSObject {
   static func toJson(_ data: [UnsignedVPToken]?) throws -> [[String: Any]] {
     let encodableUnsignedVPToken : [[String: String]] = data?.map {
       [
+        "id": $0.id,
         "dataToSign": $0.dataToSign.toBase64UrlEncoded(),
         "format": $0.format.rawValue,
         "holderKeyReference": $0.holderKeyReference,
@@ -125,8 +126,11 @@ class OpenId4VPUtils: NSObject {
       guard let signedData = vpTokenSigningResult["signedData"] as? String else {  
         throw ParseError(message: "Invalid VP token signing result: missing or invalid 'signedData'")  
       }
+      guard let id = vpTokenSigningResult["id"] as? String else {
+        throw ParseError(message: "Invalid VP token signing result: missing or invalid 'id'")
+      }
       let decodedSignedData = try decodeBase64ToData(signedData)
-      return VPTokenSigningResult(signedData: decodedSignedData)
+      return VPTokenSigningResult(id: id, signedData: decodedSignedData)
     }
       
     return vpTokenSigningResultsData

--- a/machines/openID4VP/openID4VPActions.ts
+++ b/machines/openID4VP/openID4VPActions.ts
@@ -229,7 +229,7 @@ export const openID4VPActions = (model: any) => {
 
     setSendVPShareError: model.assign({
       error: (_, event) => {
-        console.error('Error during send VP:', event.data.message, event.data.code);
+        console.error('Error during send VP:', event.data.message, event.data.code, event.data.cause);
         return 'send vp-' + event.data.message + '-' + event.data.code;
       },
     }),

--- a/shared/openID4VP/OpenID4VP.ts
+++ b/shared/openID4VP/OpenID4VP.ts
@@ -188,23 +188,6 @@ class OpenID4VP {
     return this.processSelectedVCs(vpRequest, selectedVCs, selectedDisclosuresByVc);
   }
 
-  static getSignatureSuite(key: string): string {
-    // The key is in did:jwk format, we need to extract the "crv" & "kty" parameter from the JWK to determine the signature algorithm
-    try {
-      const jwk = decodeDidJwk(key);
-      if (jwk.kty === 'OKP' && jwk.crv === 'Ed25519') {
-        return 'Ed25519Signature2020';
-      } else if (jwk.kty === 'RSA') {
-        return 'RsaSignature2018';
-      } else {
-        return 'JsonWebSignature2020';
-      }
-    } catch (error) {
-      console.error('Error parsing JWK from key: ', error);
-      return 'JsonWebSignature2020'; // default to JsonWebSignature2020 if we can't determine the algorithm
-    }
-  }
-
   static async constructUnsignedVPToken(
     vpRequest: object,
     selectedVCs: Record<string, VC[]>,

--- a/shared/openID4VP/OpenID4VPHelper.ts
+++ b/shared/openID4VP/OpenID4VPHelper.ts
@@ -72,6 +72,7 @@ export const signDataForVpPreparation = async (
     return keyTypeToKeysPromise[keyType];
   };
 
+
   const result: Promise<VPTokenSigningResult>[] = unSignedVpTokens.map(
     async unsignedVPToken => {
       let signature: string | undefined = '';

--- a/shared/openID4VP/OpenID4VPHelper.ts
+++ b/shared/openID4VP/OpenID4VPHelper.ts
@@ -88,7 +88,7 @@ export const signDataForVpPreparation = async (
         payload, // Payload is in base64 url encoded form - decode it before signing
         signatureAlgorithm,
       );
-      return {signedData: signature} as VPTokenSigningResult;
+      return {signedData: signature, id: unsignedVPToken.id} as VPTokenSigningResult;
     },
   );
 
@@ -161,5 +161,5 @@ export function claimPathPointersToJsonPath(
   return currentPath;
 }
 
-export const isDcqlFlow = (vpRequest: object) =>
-  vpRequest?.['dcql_query'] !== undefined;
+export const isDcqlFlow = (vpRequest: Record<string, unknown>) =>
+  (vpRequest as Record<string, unknown>)['dcql_query'] !== undefined;

--- a/shared/openID4VP/openid4vp.types.ts
+++ b/shared/openID4VP/openid4vp.types.ts
@@ -1,7 +1,7 @@
-import {VC} from '../../machines/VerifiableCredential/VCMetaMachine/vc';
 import {VCMetadata} from "../VCMetadata";
 
 export interface UnsignedVPToken {
+  id: string;
   format: 'ldp_vc' | 'mso_mdoc' | 'vc_sd_jwt' | 'dc_sd_jwt';
   holderKeyReference: string;
   signatureAlgorithm: string;
@@ -14,6 +14,7 @@ export interface VerifierInfo {
 }
 
 export interface VPTokenSigningResult {
+  id: string;
   signedData: string;
 }
 


### PR DESCRIPTION
## Description

### Wallet Config updates
Rename validatePreRegisteredVerifier → validateTrustedVerifier aligning with the trustedVerifiers convention
Remove supportedRequestUriMethods config

### VPTokenSigningResult / UnsignedVPToken Updates
Include id in the VPTokenSigningResult / UnsignedVPToken data

## Issue ticket number and link

- Relates: https://github.com/inji/inji-wallet/issues/2499
- Relates: https://github.com/inji/inji-wallet/issues/2498

## Dependent PRs
This PR is dependent on
1. https://github.com/inji/inji-openid4vp-ios-swift/pull/124
2. https://github.com/inji/inji-openid4vp/pull/182


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured VP signing and parsing consistently include an `id` for unsigned tokens and signing results across iOS/Android, preventing token/result mismatches.
  * Improved OpenID4VP error reporting by surfacing clearer cause details in logs for failed VP operations.
  * Updated wallet configuration interpretation for presentation-definition URI support and trusted verifier validation behavior.
* **Style**
  * Refreshed the credential disclosure key label color for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->