### PR TITLE
fix(deeplink): prevent redundant focus reads from dropping credential offer

### DIFF
--- a/machines/app.ts
+++ b/machines/app.ts
@@ -231,13 +231,14 @@ export const appMachine = model.createMachine(
             invoke: {
               src: 'checkFocusState',
             },
-            on: {
-              ACTIVE: '.active',
-              INACTIVE: '.inactive',
-            },
             initial: 'checking',
             states: {
-              checking: {},
+              checking: {
+                on: {
+                  ACTIVE: 'active',
+                  INACTIVE: 'inactive',
+                },
+              },
               active: {
                 entry: ['forwardToServices'],
                 invoke: [
@@ -266,9 +267,15 @@ export const appMachine = model.createMachine(
                     },
                   },
                 ],
+                on: {
+                  INACTIVE: 'inactive',
+                },
               },
               inactive: {
                 entry: ['forwardToServices'],
+                on: {
+                  ACTIVE: 'active',
+                },
               },
             },
           },
@@ -315,8 +322,11 @@ export const appMachine = model.createMachine(
         authorizationRequest: '',
       }),
       setCredentialOfferUri: assign({
-        credentialOfferUri: (_, event) =>
-          typeof event.data === 'string' ? event.data.trim() : '',
+        credentialOfferUri: (context, event) => {
+          const incoming =
+            typeof event.data === 'string' ? event.data.trim() : '';
+          return incoming !== '' ? incoming : context.credentialOfferUri;
+        },
       }),
       resetCredentialOfferUri: assign({
         credentialOfferUri: '',
@@ -522,7 +532,6 @@ export const appMachine = model.createMachine(
           'change',
           changeHandler,
         );
-        AppState.addEventListener('change', changeHandler);
 
         let blurEventSubscription, focusEventSubscription;
 


### PR DESCRIPTION
When the app is resumed from the background via a credential-offer deeplink, a single foreground emits several `ACTIVE` events (duplicated AppState `change` listener, Android `focus`, biometric round-trips). The parent `focus` self-transition restarted the deeplink readers on each event, and because `getCredentialOfferDeepLinkIntent` reads a read-once-and-clear native bucket, the redundant empty reads wiped a freshly captured offer URI — leaving the user on the issuer screen with no download.

This change:
- moves `ACTIVE`/`INACTIVE` handling onto the child states so `active` cannot re-enter itself,
- removes the duplicate AppState `change` listener,
- keeps a non-empty offer URI when a re-read returns empty (cleared explicitly via `RESET_CREDENTIAL_OFFER_URI`).

Cold start is unaffected (single read on the unlock transition).