### PR TITLE
refactor: update wallet-config - validate_trusted_verifier

### DIFF
--- a/shared/openID4VP/OpenID4VP.test.ts
+++ b/shared/openID4VP/OpenID4VP.test.ts
@@ -268,7 +268,7 @@ describe('OpenID4VP', () => {
     mockedGetWalletConfig.mockResolvedValue({
       mock: true,
       trusted_verifiers: [],
-      validate_pre_registered_verifier: false,
+      validate_trusted_verifier: false,
     } as never);
     mockedJsonLdCanonicalize.mockResolvedValue('');
     mockedJsonLdExpand.mockResolvedValue([]);
@@ -298,7 +298,7 @@ describe('OpenID4VP', () => {
       expect(nativeModule.initSdk).toHaveBeenCalledWith('test-app-id', {
         mock: true,
         trusted_verifiers: [],
-        validate_pre_registered_verifier: false,
+        validate_trusted_verifier: false,
       });
       expect(nativeModule.authenticateVerifier).toHaveBeenCalledWith(
         'encoded-request',
@@ -404,7 +404,7 @@ describe('OpenID4VP', () => {
       expect(nativeModule.initSdk).toHaveBeenCalledWith('test-app-id', {
         mock: true,
         trusted_verifiers: [],
-        validate_pre_registered_verifier: false,
+        validate_trusted_verifier: false,
       });
     });
   });
@@ -1012,7 +1012,7 @@ describe('OpenID4VP', () => {
       expect(nativeModule.initSdk).toHaveBeenCalledWith('test-app-id', {
         mock: true,
         trusted_verifiers: [],
-        validate_pre_registered_verifier: false,
+        validate_trusted_verifier: false,
       });
       expect(nativeModule.getMatchingCredentials).toHaveBeenCalledWith(
         {dcql_query: {query: 'example'}},

--- a/shared/openID4VP/OpenID4VPHelper.test.ts
+++ b/shared/openID4VP/OpenID4VPHelper.test.ts
@@ -76,7 +76,7 @@ describe('OpenID4VPHelper', () => {
         openid4vpWalletConfig: '{"name":"test-wallet"}',
       });
       const result = await getWalletConfig();
-      expect(result).toEqual({name: 'test-wallet', "validate_pre_registered_verifier": true, "trusted_verifiers": []});
+      expect(result).toEqual({name: 'test-wallet', "validate_trusted_verifier": true, "trusted_verifiers": []});
     });
 
     it('returns wallet config with populated wallet config, trusted verifiers and validate pre-registered verifier as per the config', async () => {
@@ -106,7 +106,7 @@ describe('OpenID4VPHelper', () => {
 
       expect(result).toEqual({
         name: 'test-wallet',
-        validate_pre_registered_verifier: true,
+        validate_trusted_verifier: true,
         trusted_verifiers: mockVerifiers,
       });
       expect(mockFetchTrustedVerifiersList).toHaveBeenCalled();

--- a/shared/openID4VP/OpenID4VPHelper.ts
+++ b/shared/openID4VP/OpenID4VPHelper.ts
@@ -25,7 +25,7 @@ export async function getWalletConfig() {
     walletConfig = parseJSON(walletConfig);
   }
 
-  walletConfig['validate_pre_registered_verifier'] =
+  walletConfig['validate_trusted_verifier'] =
     config.openid4vpClientValidation === 'true';
 
   try {

--- a/shared/openID4VP/walletConfig/WalletConfig.ts
+++ b/shared/openID4VP/walletConfig/WalletConfig.ts
@@ -28,5 +28,5 @@ export const defaultWalletConfig = {
   presentation_definition_uri_supported: true,
   request_uri_methods_supported: ['get', 'post'],
   trusted_verifiers: [],
-  validate_pre_registered_verifier: true,
+  validate_trusted_verifier: true,
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected wallet configuration so OpenID4VP validation uses the trusted verifier setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->