### PR TITLE
fix(deeplink): prevent redundant focus reads from dropping credential offer (#2509)

### DIFF
--- a/machines/app.ts
+++ b/machines/app.ts
@@ -231,13 +231,14 @@ export const appMachine = model.createMachine(
             invoke: {
               src: 'checkFocusState',
             },
-            on: {
-              ACTIVE: '.active',
-              INACTIVE: '.inactive',
-            },
             initial: 'checking',
             states: {
-              checking: {},
+              checking: {
+                on: {
+                  ACTIVE: 'active',
+                  INACTIVE: 'inactive',
+                },
+              },
               active: {
                 entry: ['forwardToServices'],
                 invoke: [
@@ -266,9 +267,15 @@ export const appMachine = model.createMachine(
                     },
                   },
                 ],
+                on: {
+                  INACTIVE: 'inactive',
+                },
               },
               inactive: {
                 entry: ['forwardToServices'],
+                on: {
+                  ACTIVE: 'active',
+                },
               },
             },
           },
@@ -315,8 +322,11 @@ export const appMachine = model.createMachine(
         authorizationRequest: '',
       }),
       setCredentialOfferUri: assign({
-        credentialOfferUri: (_, event) =>
-          typeof event.data === 'string' ? event.data.trim() : '',
+        credentialOfferUri: (context, event) => {
+          const incoming =
+            typeof event.data === 'string' ? event.data.trim() : '';
+          return incoming !== '' ? incoming : context.credentialOfferUri;
+        },
       }),
       resetCredentialOfferUri: assign({
         credentialOfferUri: '',
@@ -527,7 +537,6 @@ export const appMachine = model.createMachine(
           'change',
           changeHandler,
         );
-        AppState.addEventListener('change', changeHandler);
 
         let blurEventSubscription, focusEventSubscription;
 


### PR DESCRIPTION
Prevents a freshly captured credential offer deeplink from being dropped when the app foregrounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of focus state changes between active and inactive modes.
  * Preserved existing credential offer information when new data is empty or unavailable.
  * Fixed cleanup of focus-state listeners to prevent lingering subscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->